### PR TITLE
Added ability to manually specify file type on .open()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,11 @@ see http://roo.rubyforge.org for a more complete tutorial
 
     xls = Roo::Spreadsheet.open('./new_prices.xls')
 
+		# If the File.path or provided path string does not have an extension, you can optionally 
+		# provide one as a string or symbol
+		
+		xls = Roo::Spreadsheet.open('./rails_temp_upload', extension: :xls)
+		
     # no more setting xls.default_sheet, just use this
 
     xls.sheet('Info').row_count

--- a/lib/roo.rb
+++ b/lib/roo.rb
@@ -4,21 +4,25 @@ module Roo
 
   class Spreadsheet
     class << self
-      def open(file)
+      def open(file, opts = {})
         file = File === file ? file.path : file
-        case File.extname(file)
+        
+        extension = opts[:extension] ? ".#{opts[:extension]}" : File.extname(file)
+        file_warning = opts[:extension] ? :ignore : :error
+        
+        case extension
         when '.xls'
-          Roo::Excel.new(file)
+          Roo::Excel.new(file, nil, file_warning)
         when '.xlsx'
-          Roo::Excelx.new(file)
+          Roo::Excelx.new(file, nil, file_warning)
         when '.ods'
-          Roo::Openoffice.new(file)
+          Roo::Openoffice.new(file, nil, file_warning)
         when '.xml'
-          Roo::Excel2003XML.new(file)
+          Roo::Excel2003XML.new(file, nil, file_warning)
         when ''
           Roo::Google.new(file)
         when '.csv'
-          Roo::Csv.new(file)
+          Roo::Csv.new(file, nil, file_warning)
         else
           raise ArgumentError, "Don't know how to open file #{file}"
         end


### PR DESCRIPTION
On `.open`, Roo depends on the extension of the file name to determine the file type and open the file properly. In some instances, a file extension may not be available. For instance, form-based file uploads in Rails often produce temporary files without extension names. 

This branch allows manual specification of the file extension for these scenarios.
