### PR TITLE
Fixes for ODS reading with nokogiri 1.5.6 

### DIFF
--- a/lib/roo/openoffice.rb
+++ b/lib/roo/openoffice.rb
@@ -183,7 +183,7 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
   def sheets
     return_sheets = []
     @doc.xpath("//*[local-name()='table']").each do |sheet|
-      return_sheets << sheet["table:name"]
+      return_sheets << sheet.attributes["name"].value
     end
     return_sheets
   end
@@ -270,7 +270,7 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
   # read the version of the OO-Version
   def oo_version
     @doc.xpath("//*[local-name()='document-content']").each do |office|
-      @officeversion = office['office:version']
+      @officeversion = safe_attr(office,'version')
     end
   end
 
@@ -298,10 +298,10 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
       @cell[sheet][key] = str_v
     when :date
       #TODO: if table_cell.attributes['date-value'].size != "XXXX-XX-XX".size
-      if table_cell['office:date-value'].size != "XXXX-XX-XX".size
+      if safe_attr(table_cell,'date-value').size != "XXXX-XX-XX".size
         #-- dann ist noch eine Uhrzeit vorhanden
         #-- "1961-11-21T12:17:18"
-        @cell[sheet][key] = DateTime.parse(table_cell['office:date-value'].to_s)
+        @cell[sheet][key] = DateTime.parse(safe_attr(table_cell,'date-value').to_s)
         @cell_type[sheet][key] = :datetime
       else
         @cell[sheet][key] = table_cell.attributes['date-value']
@@ -327,7 +327,7 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
     sheet_found = false
 
     @doc.xpath("//*[local-name()='table']").each do |ws|
-      if sheet == ws['table:name']
+      if sheet == safe_attr(ws,'name')
         sheet_found = true
         col = 1
         row = 1
@@ -337,15 +337,15 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
             @style_defaults[sheet] << table_element.attributes['default-cell-style-name']
           when 'table-row'
             if table_element.attributes['number-rows-repeated']
-              skip_row = table_element['table:number-rows-repeated'].to_s.to_i
+              skip_row = safe_attr(table_element,'number-rows-repeated').to_s.to_i
               row = row + skip_row - 1
             end
             table_element.children.each do |cell|
-              skip_col = cell['table:number-columns-repeated']
-              formula = cell['office:formula']
-              value_type = cell['office:value-type']
-              v =  cell['office:value']
-              style_name = cell['style-name']
+              skip_col = safe_attr(cell, 'number-columns-repeated')
+              formula = safe_attr(cell,'formula')
+              value_type = safe_attr(cell,'value-type')
+              v =  safe_attr(cell,'value')
+              style_name = safe_attr(cell,'style-name')
               case value_type
               when 'string'
                 str_v  = ''
@@ -406,7 +406,7 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
               when 'float'
                 #
               when 'boolean'
-                v = cell['office:boolean-value'].to_s
+                v = safe_attr(cell,'boolean-value').to_s
               else
                 # raise "unknown type #{value_type}"
               end
@@ -448,8 +448,8 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
       #-
       # $Sheet1.$C$5
       #+
-      name = ne.attribute('name').to_s
-      sheetname,coords = ne.attribute('cell-range-address').to_s.split('.$')
+      name = safe_attr(ne,'name').to_s
+      sheetname,coords = safe_attr(ne,'cell-range-address').to_s.split('.$')
       col, row = coords.split('$')
       sheetname = sheetname[1..-1] if sheetname[0,1] == '$'
       [name, [sheetname,row,col]]
@@ -460,12 +460,12 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
     @style_definitions['Default'] = Roo::Openoffice::Font.new
     style_elements.each do |style|
       next unless style.name == 'style'
-      style_name = style.attributes['name']
+      style_name = safe_attr(style,'name')
       style.each do |properties|
         font = Roo::Openoffice::Font.new
-        font.bold = properties.attributes['font-weight']
-        font.italic = properties.attributes['font-style']
-        font.underline = properties.attributes['text-underline-style']
+        font.bold = safe_attr(properties,'font-weight')
+        font.italic = safe_attr(properties,'font-style')
+        font.underline = safe_attr(properties,'text-underline-style')
         @style_definitions[style_name] = font
       end
     end
@@ -504,6 +504,16 @@ class Roo::Openoffice < Roo::GenericSpreadsheet
       end
     }
     result
+  end
+
+
+  private
+  def safe_attr(node, attr_name)
+    if node.attributes[attr_name] then
+      node.attributes[attr_name].value
+    else
+      nil
+    end
   end
 
 end # class


### PR DESCRIPTION
[] operator on XML nodes now requires the namespace to be specified
reading of ODS files was broken in roo 1.10.2 + Nokogiri 1.5.6

Signed-off-by: Karsten Richter kasi@kasi-net.org
