### PR TITLE
Discard empty rows before reading them.

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -98,9 +98,9 @@ class Roo::Excelx < Roo::GenericSpreadsheet
         read_styles(@styles_doc)
       end
       @sheet_doc = @sheet_files.map do |item|
-        File.open(item) do |file|
-          Nokogiri::XML(file)
-        end
+        file = File.read item
+        file.gsub! /<row [^>]+>(?:<c [^>]+\/>)*<\/row>/, ''
+        Nokogiri::XML(file)
       end
       @comments_doc = @comments_files.map do |item|
         File.open(item) do |file|


### PR DESCRIPTION
This can massively speed up the reading of an xlsx spreadsheet.  It was
motivated by trying to read a spreadsheet with 900 rows of content and
900,000 empty rows.  Before this change it took tens of minutes or
longer; after the change it took a few seconds.
