### PR TITLE
Fix broken type inference from currency to float in Excelx

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -7,9 +7,7 @@ class Roo::Excelx < Roo::GenericSpreadsheet
     EXCEPTIONAL_FORMATS = {
       'h:mm am/pm' => :date,
       'h:mm:ss am/pm' => :date,
-      'm/d/yy h:mm' => :date,
-      '#,##0 ;[red](#,##0)' => :float,
-      '#,##0.00;[red](#,##0.00)' => :float
+      'm/d/yy h:mm' => :date
     }
 
     STANDARD_FORMATS = {
@@ -47,6 +45,8 @@ class Roo::Excelx < Roo::GenericSpreadsheet
       format = format.to_s.downcase
       if type = EXCEPTIONAL_FORMATS[format]
         type
+      elsif format.include?('#')
+        :float
       elsif format.include?('d') || format.include?('y')
         if format.include?('h') || format.include?('s')
           :datetime

--- a/spec/lib/roo/excelx/format_spec.rb
+++ b/spec/lib/roo/excelx/format_spec.rb
@@ -26,6 +26,7 @@ describe Roo::Excelx::Format do
       '#,##0 ;[Red](#,##0)' => :float,
       '#,##0.00;(#,##0.00)' => :float,
       '#,##0.00;[Red](#,##0.00)' => :float,
+      '#,##0_);[Red](#,##0)' => :float,
       'mm:ss' => :time,
       '[h]:mm:ss' => :time,
       'mmss.0' => :time,


### PR DESCRIPTION
The type inference that Excelx#to_type does is broken for at least
one valid currency format. Check out this xlsx file:

http://scpike-drop.s3.amazonaws.com/broken.xlsx

> Roo::Excelx.new("broken.xlsx")
>  => {[1, 1]=>"1899-12-30"}

The problem is that EXCEPTIONAL_FORMATS doesn't handle every type of
currency format that excel does. This format code has a "d" in it
(from "Red") so it gets marked as a date. Rather than hardcoding the
list of that are floats, can we just assume all formats with # are
floats? My interpretation of §18.8.31 in the
[spec](http://www.ecma-international.org/publications/standards/Ecma-376.htm) says yes.

This is not a problem in Roo::Excel, just Roo::Excelx
