### PR TITLE
Enable CSV files to be loaded from a URI

### DIFF
--- a/lib/roo/csv.rb
+++ b/lib/roo/csv.rb
@@ -17,6 +17,15 @@ class Roo::Csv < Roo::GenericSpreadsheet
     @last_row = Hash.new
     @first_column = Hash.new
     @last_column = Hash.new
+
+    make_tmpdir do |tmpdir|
+      @data =
+        File.open(
+          uri?(filename) ?
+            open_from_uri(filename, tmpdir) :
+            filename
+        ) { |f| f.read }
+    end
   end
 
   # Returns an array with the names of the sheets. In Csv class there is only
@@ -65,7 +74,7 @@ class Roo::Csv < Roo::GenericSpreadsheet
     @first_column[sheet] = 1
     @last_column[sheet] = 1
     rownum = 1
-    CSV.foreach(@filename) do |row|
+    CSV.parse @data do |row|
       row.each_with_index do |elem,i|
         @cell[[rownum,i+1]] = cell_postprocessing rownum,i+1, elem
         @cell_type[[rownum,i+1]] = celltype_class @cell[[rownum,i+1]]


### PR DESCRIPTION
Unlike other spreadsheet formats, CSV files currently can't be loaded from a URI. This change adds that functionality to the `Roo::Csv` class.
