### PR TITLE
Fix deprecation typo

### DIFF
--- a/lib/roo/excel.rb
+++ b/lib/roo/excel.rb
@@ -20,7 +20,7 @@ class Roo::Excel < Roo::Base
       packed = options[:packed]
       file_warning = options[:file_warning] || :error
     else
-      warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excel.new` is deprected. Use an options hash instead.'
+      warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excel.new` is deprecated. Use an options hash instead.'
       packed = options
       file_warning = deprecated_file_warning
     end

--- a/lib/roo/excel2003xml.rb
+++ b/lib/roo/excel2003xml.rb
@@ -11,7 +11,7 @@ class Roo::Excel2003XML < Roo::Base
       packed = options[:packed]
       file_warning = options[:file_warning] || :error
     else
-      warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excel2003XML.new` is deprected. Use an options hash instead.'
+      warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excel2003XML.new` is deprecated. Use an options hash instead.'
       packed = options
       file_warning = deprecated_file_warning
     end

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -70,7 +70,7 @@ class Roo::Excelx < Roo::Base
       packed = options[:packed]
       file_warning = options[:file_warning] || :error
     else
-      warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excelx.new` is deprected. Use an options hash instead.'
+      warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excelx.new` is deprecated. Use an options hash instead.'
       packed = options
       file_warning = deprecated_file_warning
     end

--- a/lib/roo/openoffice.rb
+++ b/lib/roo/openoffice.rb
@@ -36,7 +36,7 @@ class Roo::OpenOffice < Roo::Base
       file_warning = options[:file_warning] || :error
       tmpdir_root = options[:tmpdir_root]
     else
-      warn 'Supplying `packed`, `file_warning`, or `tmpdir_root` as separate arguments to `Roo::OpenOffice.new` is deprected. Use an options hash instead.'
+      warn 'Supplying `packed`, `file_warning`, or `tmpdir_root` as separate arguments to `Roo::OpenOffice.new` is deprecated. Use an options hash instead.'
       packed = options
       file_warning = deprecated_file_warning
       tmpdir_root = deprecated_tmpdir_root


### PR DESCRIPTION
"Deprecated" was misspelled as "Deprected"
