### PR TITLE
changing rubyzip gem dependency verion to <1,

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -183,20 +183,20 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<spreadsheet>, ["> 0.6.4"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
-      s.add_runtime_dependency(%q<rubyzip>, [">= 0"])
+      s.add_runtime_dependency(%q<rubyzip>, ["<1"])
       s.add_development_dependency(%q<google_drive>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
       s.add_dependency(%q<spreadsheet>, ["> 0.6.4"])
       s.add_dependency(%q<nokogiri>, [">= 0"])
-      s.add_dependency(%q<rubyzip>, [">= 0"])
+      s.add_dependency(%q<rubyzip>, ["<1"])
       s.add_dependency(%q<google_drive>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
     s.add_dependency(%q<spreadsheet>, ["> 0.6.4"])
     s.add_dependency(%q<nokogiri>, [">= 0"])
-    s.add_dependency(%q<rubyzip>, [">= 0"])
+    s.add_dependency(%q<rubyzip>, ["<1"])
     s.add_dependency(%q<google_drive>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
   end


### PR DESCRIPTION
 because the new 1.0.0 rubyzip version breaks compatiblity with roo.

the file 'zip/zipfilesystem' required by /lib/roo/base.rb has been removed from rubyzip in the 1.0.0 stable version.
