### PR TITLE
Fixes remote CSV filename from getting set to 'nil'.

### DIFF
--- a/lib/roo/csv.rb
+++ b/lib/roo/csv.rb
@@ -60,8 +60,8 @@ class Roo::CSV < Roo::Base
   def each_row(options, &block)
     if uri?(filename)
       make_tmpdir do |tmpdir|
-        filename = download_uri(filename, tmpdir)
-        CSV.foreach(filename, options, &block)
+        tmp_filename = download_uri(filename, tmpdir)
+        CSV.foreach(tmp_filename, options, &block)
       end
     else
       CSV.foreach(filename, options, &block)


### PR DESCRIPTION
Rails 4, Ruby 2.0.0, carrierwave, Heroku -- 
When creating a CSV with a URL  ( `Roo::CSV.new(remote_csv_url)`) , was throwing 

``` ruby
TypeError (no implicit conversion of nil into String)
```

`make_tmpdir` was nil-ing the local `filename` by using both a local assignment and calling the filename instance var.
