### PR TITLE
Support sheets in Base#to_matrix

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -208,7 +208,7 @@ class Roo::Base
 
     Matrix.rows((from_row||first_row(sheet)).upto(to_row||last_row(sheet)).map do |row|
       (from_column||first_column(sheet)).upto(to_column||last_column(sheet)).map do |col|
-        cell(row,col)
+        cell(row,col,sheet)
       end
     end)
   end

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -1771,6 +1771,16 @@ Sheet 3:
     end
   end
 
+  def test_matrix_specifying_sheet
+    with_each_spreadsheet(:name => 'matrix', :format => [:openoffice, :excel, :google]) do |oo|
+      oo.default_sheet = oo.sheets.first
+      assert_equal Matrix[
+        [1.0, nil, 3.0],
+        [4.0, 5.0, 6.0],
+        [7.0, 8.0, nil] ], oo.to_matrix(nil, nil, nil, nil, 'Sheet3')
+    end
+  end
+
   # unter Windows soll es laut Bug-Reports nicht moeglich sein, eine Excel-Datei, die
   # mit Excel.new geoeffnet wurde nach dem Processing anschliessend zu loeschen.
   # Anmerkung: Das Spreadsheet-Gem erlaubt kein explizites Close von Spreadsheet-Dateien,


### PR DESCRIPTION
`Base#to_matrix` always used the default sheet despite accepting a `sheet` argument because it did not pass the `sheet` through to `#cell`.
