### PR TITLE
Add :mode option, passed to Spreadsheet.open

### DIFF
--- a/lib/roo/excel.rb
+++ b/lib/roo/excel.rb
@@ -35,7 +35,7 @@ class Roo::Excel < Roo::Base
       unless File.file?(@filename)
         raise IOError, "file #{@filename} does not exist"
       end
-      @workbook = Spreadsheet.open(filename)
+      @workbook = Spreadsheet.open(filename, options[:mode] || "rb+")
     end
     super(filename, options)
     @formula = Hash.new


### PR DESCRIPTION
On a project where I need to open spreadsheets in read-only mode, I ended-up with this patch.

WDYT
