### PR TITLE
Exporting link url when converting spreadsheet to csv

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -778,6 +778,8 @@ class Roo::Base
         onecell.to_s
       when :time
         Roo::Base.integer_to_timestring(onecell)
+      when :link
+          %{"#{onecell.url.gsub(/"/,'""')}"}
       else
         raise "unhandled celltype #{celltype(row,col,sheet)}"
       end || ""

--- a/test/files/link.csv
+++ b/test/files/link.csv
@@ -1,0 +1,1 @@
+"http://www.google.com"

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -1113,7 +1113,19 @@ Sheet 3:
       end
     end
   end
-
+  def test_link_to_csv
+    with_each_spreadsheet(:name=>'link',:format=>:excel) do |oo|
+      Dir.mktmpdir do |tempdir|
+        csv_output = File.join(tempdir,'link.csv')
+        assert oo.to_csv(csv_output)
+        assert File.exists?(csv_output)
+puts `diff --strip-trailing-cr #{TESTDIR}/link.csv #{csv_output}`
+        assert_equal "", `diff --strip-trailing-cr #{TESTDIR}/link.csv #{csv_output}`
+        # --strip-trailing-cr is needed because the test-file use 0A and
+        # the test on an windows box generates 0D 0A as line endings
+      end
+    end
+  end
   def test_date_time_yaml
     with_each_spreadsheet(:name=>'time-test') do |oo|
       expected =


### PR DESCRIPTION
If the celltype was a link, the behaviour was raising an unhandled celltype exception. 
I believe the best solution for this case (at least for my use case) is exporting the url of the link.
