### PR TITLE
Properly process paths/files with spaces in them.

### DIFF
--- a/lib/roo/spreadsheet.rb
+++ b/lib/roo/spreadsheet.rb
@@ -9,7 +9,7 @@ module Roo
             options[:file_warning] = :ignore
             ".#{options.delete(:extension)}".gsub(/[.]+/, ".")
           else
-            File.extname(URI.parse(file).path)
+            File.extname(URI.decode(URI.parse(URI.encode(file)).path))
           end
 
         case extension.downcase

--- a/spec/lib/roo/spreadsheet_spec.rb
+++ b/spec/lib/roo/spreadsheet_spec.rb
@@ -44,6 +44,15 @@ describe Roo::Spreadsheet do
       end
     end
 
+    context "with spaces in the filename" do
+      let(:filename) { 'path with spaces.xls'}
+
+      it 'loads the proper type' do
+        expect(Roo::Excel).to receive(:new).with(filename, {})
+        Roo::Spreadsheet.open(filename)
+      end
+    end
+
     context 'with a file extension option' do
       let(:filename) { 'file.xls' }
 


### PR DESCRIPTION
Fixes the following (new) test:

```
1) Roo::Spreadsheet.open with spaces in the filename loads the proper type
   Failure/Error: Roo::Spreadsheet.open(filename)
   URI::InvalidURIError:
     bad URI(is not URI?): path with spaces.xls
   # ./lib/roo/spreadsheet.rb:12:in `open'
```
