### PR TITLE
Add option to set comment xpath

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -70,6 +70,7 @@ class Roo::Excelx < Roo::Base
     if Hash === options
       packed = options[:packed]
       file_warning = options[:file_warning] || :error
+      @comment_xpath = options[:comment_xpath] || './xmlns:text/xmlns:r/xmlns:t'
     else
       warn 'Supplying `packed` or `file_warning` as separate arguments to `Roo::Excelx.new` is deprecated. Use an options hash instead.'
       packed = options
@@ -524,7 +525,7 @@ Datei xl/comments1.xml
     @comments_doc[n].xpath("//xmlns:comments/xmlns:commentList/xmlns:comment").each do |comment|
       ref = comment.attributes['ref'].to_s
       row,col = Roo::Base.split_coordinate(ref)
-      comment.xpath('./xmlns:text/xmlns:r/xmlns:t').each do |text|
+      comment.xpath(@comment_xpath).each do |text|
         @comment[sheet] ||= {}
         @comment[sheet][[row,col]] = text.text
       end

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -2289,4 +2289,12 @@ where the expected result is
     end
   end
 
+  def test_comment_xpath_option
+    sheet =
+      Roo::Excelx.new('test/files/comment_sheet.xlsx',
+                      comment_xpath: './xmlns:text/xmlns:t')
+
+    assert_equal false, sheet.comments.empty?
+  end
+
 end # class


### PR DESCRIPTION
I am using Roo::Excelx to read comments made on xlsx spreadsheets, and found that the xml structure of the comments file was different than the regex used by roo (when I exported to xlsx from google spreadsheets).

This PR allows the comment_xpath to be user specified, via an option