### PR TITLE
RSpec >= 2.14 is required for tests to pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :test do
   # additional testing libs
   gem 'webmock'
   gem 'shoulda'
-  gem 'rspec'
+  gem 'rspec', '>= 2.14'
   gem 'vcr'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.3.5)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
-    diff-lcs (1.2.1)
+    diff-lcs (1.2.4)
     faraday (0.8.7)
       multipart-post (~> 1.1)
     git (1.2.5)
@@ -39,14 +39,14 @@ GEM
     rake (0.9.2.2)
     rdoc (3.12.2)
       json (~> 1.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.3)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.0)
+    rspec-mocks (2.14.3)
     ruby-ole (1.2.11.6)
     rubyzip (1.0.0)
     safe_yaml (0.9.4)
@@ -70,7 +70,7 @@ DEPENDENCIES
   google_drive
   jeweler
   nokogiri
-  rspec
+  rspec (>= 2.14)
   rubyzip
   shoulda
   spreadsheet (> 0.6.4)


### PR DESCRIPTION
I noticed specs are no passing on my computer because I had rspec < 2.14 installed which doesn't support .receive syntax. This PR should fix this issue.
