### PR TITLE
prevent ArgumentError: wrong number of arguments (0 for 1) in Roo::Base#...

### DIFF
--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -702,6 +702,20 @@ class TestRoo < Test::Unit::TestCase
     end
   end
 
+  def test_find_by_row_if_header_line_is_not_nil
+    with_each_spreadsheet(:name=>'numbers1') do |oo|
+      oo.header_line = 2
+      assert_not_nil oo.header_line
+      rec = oo.find 1
+      assert rec
+      assert_equal 5, rec[0]
+      assert_equal 6, rec[1]
+      rec = oo.find 15
+      assert rec
+      assert_equal "einundvierzig", rec[0]
+    end
+  end
+
   def test_find_by_conditions
     if LONG_RUN
       with_each_spreadsheet(:name=>'Bibelbund', :format=>[:openoffice,


### PR DESCRIPTION
...find by row number if header_line is not nil.

Roo::Base#find not works with row number as argument if header_line is set. 
I think this need to be fixed because header line is not nil as default:
https://github.com/Empact/roo/blob/master/lib/roo/base.rb#L61

Output from console:
1.9.2-p320 :010 > excel = Roo::Excel.new("/Users/file.xls")
1.9.2-p320 :017 >   excel.header_line
 => 1
1.9.2-p320 :018 > excel.find(1)
ArgumentError: wrong number of arguments (0 for 1)
from /Users/funkydrummer/.rvm/gems/ruby-1.9.2-p320/gems/roo-1.13.2/lib/roo/base.rb:263:in `row'
from /Users/funkydrummer/.rvm/gems/ruby-1.9.2-p320/gems/roo-1.13.2/lib/roo/base.rb:229:in`find'
from (irb):18
from /Users/funkydrummer/.rvm/rubies/ruby-1.9.2-p320/bin/irb:16:in `<main>'

This pull request fix this issue.
So, now:
excel.header_line = 5
excel.row(1) - return first row
excel.find(1) - return fifth row of spreadsheet
