### PR TITLE
Add capability to specify separator to to_csv

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -183,16 +183,16 @@ class Roo::Base
   end
 
   # write the current spreadsheet to stdout or into a file
-  def to_csv(filename=nil,sheet=nil)
+  def to_csv(filename=nil,sheet=nil,separator=',')
     sheet ||= @default_sheet
     if filename
       File.open(filename,"w") do |file|
-        write_csv_content(file,sheet)
+        write_csv_content(file,sheet,separator)
       end
       return true
     else
       sio = StringIO.new
-      write_csv_content(sio,sheet)
+      write_csv_content(sio,sheet,separator)
       sio.rewind
       return sio.read
     end
@@ -728,12 +728,12 @@ class Roo::Base
 
   # Write all cells to the csv file. File can be a filename or nil. If the this
   # parameter is nil the output goes to STDOUT
-  def write_csv_content(file=nil,sheet=nil)
+  def write_csv_content(file=nil,sheet=nil,separator=',')
     file ||= STDOUT
     if first_row(sheet) # sheet is not empty
       1.upto(last_row(sheet)) do |row|
         1.upto(last_column(sheet)) do |col|
-          file.print(",") if col > 1
+          file.print(separator) if col > 1
           file.print cell_to_csv(row,col,sheet)
         end
         file.print("\n")

--- a/test/test_generic_spreadsheet.rb
+++ b/test/test_generic_spreadsheet.rb
@@ -174,6 +174,10 @@ class TestBase < Test::Unit::TestCase
   def test_to_csv
     assert_equal expected_csv,@oo.to_csv
   end
+
+  def test_to_csv_with_separator
+    assert_equal expected_csv_with_semicolons,@oo.to_csv(nil, nil, ';')
+  end
 protected
   def setup_test_sheet(workbook=nil)
     workbook ||= @oo
@@ -255,5 +259,8 @@ protected
 
   def expected_csv
     ",,,,,,\n,,,,,,\n,,,,,,\n,,,,,,\n1961-11-21,,,,,,\n,,,,,,\n,,,,,,\n,,\"thisisc8\",,,,\"thisisg8\"\n,,,,,,\n,,,,,,\n,,,,,,\n41,42,43,44,45,,\n,,,,,,\n,,,,,,\n,,43,44,45,,\n,,\"dreiundvierzig\",\"vierundvierzig\",\"fuenfundvierzig\",,\n"
+  end
+  def expected_csv_with_semicolons
+    expected_csv.gsub /\,/, ';' 
   end
 end


### PR DESCRIPTION
Just a note: Before adding this feature, there were a couple of existing tests failing. I added a test for this feature though, and the output from rake test is the same as before the change. 

See below for output from rake test (running ruby 1.9.3p392), if this is not expected and existing tests are actually not breaking for you.

```
  1) Failure:
test_bug_datetime_to_csv(TestRoo) [/Users/nicke/code/roo/test/test_roo.rb:1887]:
<""> expected but was
<"<1961-11-21T12:17:18+00:00,1961-11-21T12:17:18+00:00,1961-11-21T12:17:18+00:00\n>1961-11-21T12:17:17+00:00,1961-11-21T12:17:17+00:00,1961-11-21T12:17:17+00:00\n<1961-11-21T12:17:18+00:00,1961-11-21T12:17:18+00:00,1961-11-21T12:17:18+00:00\n>1961-11-21T12:17:17+00:00,1961-11-21T12:17:17+00:00,1961-11-21T12:17:17+00:00\n<1961-11-21T12:17:18+00:00,1961-11-21T12:17:18+00:00,1961-11-21T12:17:18+00:00\n>1961-11-21T12:17:17+00:00,1961-11-21T12:17:17+00:00,1961-11-21T12:17:17+00:00\n">.

  2) Error:
test_bug_pfand_from_windows_phone_xlsx(TestRoo):
Encoding::CompatibilityError: incompatible encoding regexp match (US-ASCII regexp with UTF-16 string) for excelx
(... removed stacktrace ...)

  3) Failure:
test_datetime(TestRoo) [/Users/nicke/code/roo/test/test_roo.rb:1369]:
<#<DateTime: 1961-11-21T12:17:18+00:00 ((2437625j,44238s,0n),+0s,2299161j)>> expected but was
<#<DateTime: 1961-11-21T12:17:17+00:00 ((2437625j,44237s,0n),+0s,2299161j)>>.
```
