### PR TITLE
Prevent inspect from being called recursively

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -212,6 +212,11 @@ class Roo::Base
     end)
   end
 
+  # call to_s method defined on subclasses
+  def inspect
+    to_s
+  end
+
   # find a row either by row number or a condition
   # Caution: this works only within the default sheet -> set default_sheet before you call this method
   # (experimental. see examples in the test_roo.rb file)


### PR DESCRIPTION
This is related to the problems with 2.0.0 and the Spreadsheet gem.

It appears this simple fix will prevent absurdly long load times on calls like:

```
spreadsheet = Roo::Excel.new("foo.xls")
```

as opposed to:

```
Roo::Excel.new("foo.xls").first_line
```

which has always run quite quickly.

The difference is the first version, when called in a program like IRB implicitly calls inspect, which (I think?) recursively calls inspect on all the nested instance variables, again, I think. Even files of a relatively small size (165kb xls) were taking hours to load before I made this change, now it takes a brief second.
