### PR TITLE
fix #84 check if the filename is String

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -659,7 +659,11 @@ class Roo::Base
   end
 
   def uri?(filename)
-    filename.is_a? String and filename.start_with?("http://", "https://")
+    begin
+      filename.start_with?("http://", "https://")
+    rescue
+      false
+    end
   end
 
   def download_uri(uri, tmpdir)

--- a/lib/roo/excel.rb
+++ b/lib/roo/excel.rb
@@ -30,7 +30,7 @@ class Roo::Excel < Roo::Base
     file_type_check(filename,'.xls','an Excel', file_warning, packed)
     make_tmpdir do |tmpdir|
       filename = download_uri(filename, tmpdir) if uri?(filename)
-      filename = open_from_stream(filename[7..-1], tmpdir) if String === filename && filename[0,7] == "stream:"
+      filename = open_from_stream(filename[7..-1], tmpdir) if filename.is_a?(::String) && filename[0,7] == "stream:"
       filename = unzip(filename, tmpdir) if packed == :zip
 
       @filename = filename

--- a/test/test_generic_spreadsheet.rb
+++ b/test/test_generic_spreadsheet.rb
@@ -102,6 +102,21 @@ class TestBase < Test::Unit::TestCase
     end
   end
 
+  context 'private method Roo::Base.uri?(filename)' do
+    should "return true when passed a filename starts with http(s)://" do
+      assert_equal true, @oo.send(:uri?, 'http://example.com/')
+      assert_equal true, @oo.send(:uri?, 'https://example.com/')
+    end
+
+    should "return false when passed a filename which does not start with http(s)://" do
+      assert_equal false, @oo.send(:uri?, 'example.com')
+    end
+
+    should "return false when passed non-String object such as Tempfile" do
+      assert_equal false, @oo.send(:uri?, Tempfile.new('test'))
+    end
+  end
+
   def test_setting_invalid_type_does_not_update_cell
     @oo.set(1,1,1)
     assert_raise(ArgumentError){@oo.set(1,1, :invalid_type)}


### PR DESCRIPTION
`filename` could be `Tempfile`, for instance. To make #84 case working, you may need to add `file_warning: :warning` when initialize the instance since `Tempfile`'s filename has no extension. `Roo::Excelx.new(params[:file].tempfile, file_warning: :ignore)`
