### PR TITLE
Fixed header row type mixup.

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -593,8 +593,8 @@ class Roo::Base
   def set_headers(hash={})
     # try to find header row with all values or give an error
     # then create new hash by indexing strings and keeping integers for header array
-    @headers = row_with(hash.values,true)
-    @headers = Hash[hash.keys.zip(@headers.map {|x| header_index(x)})]
+    @header_line = row_with(hash.values,true)
+    @headers = Hash[hash.keys.zip(row(@header_line).map {|x| header_index(x)})]
   end
 
   def header_index(query)


### PR DESCRIPTION
When using sheet.parse() with a columns hash, I got the following error:

    lib/roo/base.rb:588:in `set_headers': undefined method `map' for 1:Fixnum (NoMethodError)

Example code:

    xls = Roo::Spreadsheet.open filepath
    columns = {
      this: "This",
      that: "That"
    }
    rows = xls.sheet(0).parse columns <-- BOOM

Unless I'm using things incorrectly, this seems like a bug.