### PR TITLE
Move .strip to after .pack in sanitize_value

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -587,7 +587,7 @@ class Roo::Base
   end
 
   def sanitize_value(v)
-    v.strip.unpack('U*').select {|b| b < 127}.pack('U*')
+    v.unpack('U*').select {|b| b < 127}.pack('U*').strip
   end
 
   def set_headers(hash={})


### PR DESCRIPTION
Before:

``` ruby
" whitespace and unicode #{128.chr('UTF-8')} ".strip.unpack('U*').select {|b| b < 127}.pack('U*')
#=> "whitespace and unicode "
```

After:

``` ruby
" whitespace and unicode #{128.chr('UTF-8')} ".unpack('U*').select {|b| b < 127}.pack('U*').strip
#=> "whitespace and unicode"
```
