### PR TITLE
Fix when opening spreadsheet with space in filename

### DIFF
--- a/lib/roo/spreadsheet.rb
+++ b/lib/roo/spreadsheet.rb
@@ -9,7 +9,7 @@ module Roo
             options[:file_warning] = :ignore
             ".#{options.delete(:extension)}".gsub(/[.]+/, ".")
           else
-            File.extname((path =~ URI::regexp) ? URI.parse(path).path : path)
+            File.extname((path =~ URI::regexp) ? URI.parse(URI.encode(path)).path : path)
           end
 
         case extension.downcase


### PR DESCRIPTION
`URI::InvalidURIError` is raised when attempting to open a spreadsheet with spaces in the filepath. This is caused by the behaviour of the URI package. This is fixed by encoding the filepath with `URI.encode` before calling `URI.parse`.
