### PR TITLE
Fix for `number_to_letter` when mathn has been required

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -17,7 +17,7 @@ class Roo::Base
   include Enumerable
 
   TEMP_PREFIX = "oo_"
-  LETTERS = %w{A B C D E F G H I J K L M N O P Q R S T U V W X Y Z}
+  LETTERS = ('A'..'Z').to_a
 
   attr_reader :default_sheet, :headers
 
@@ -48,12 +48,12 @@ class Roo::Base
       if n > 26
         while n % 26 == 0 && n != 0
           letters << 'Z'
-          n = (n - 26) / 26
+          n = ((n - 26) / 26).to_i
         end
         while n > 0
           num = n%26
           letters = LETTERS[num-1] + letters
-          n = (n / 26)
+          n = (n / 26).to_i
         end
       else
         letters = LETTERS[n-1]


### PR DESCRIPTION
The `number_to_letter` method expects `1 / 26 == 0`, which isn't true if the `mathn` library has been included.

See it in action, open `irb -r roo`:

``` ruby
Roo::Base.number_to_letter(27)
# => "AA"
require "mathn"
Roo::Base.number_to_letter(27)
# never finishes executing
```

This is because including `mathn` [duck punches the divide operator](https://github.com/ruby/ruby/blob/trunk/lib/mathn.rb#L11-L17) into returning a `Rational` instead of an integer,  ensuring [the while loop in this method](https://github.com/Empact/roo/blob/master/lib/roo/base.rb#L53-L57) never ends.

This PR casts the result of the divide to integer, returning the desired output.
