### PR TITLE
Calling Roo::Base#sheet returns the specified sheet

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -314,7 +314,7 @@ class Roo::Base
   # access different worksheets by calling spreadsheet.sheet(1)
   # or spreadsheet.sheet('SHEETNAME')
   def sheet(index, name = false)
-    default_sheet = String === index ? index : sheets[index]
+    self.default_sheet = String === index ? index : sheets[index]
     name ? [default_sheet, self] : self
   end
 


### PR DESCRIPTION
The Roo::Base#sheet method was not returning the sheet specified when using either an index or name. This PR fixes the issue.

Related issue #140

Thanks,
-Matt
