### PR TITLE
Support 0 based sheet numbering

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -510,7 +510,7 @@ class Roo::Excelx < Roo::Base
           # lead to sheet references getting overwritten, so we need to
           # handle that case specifically.
           nr = $1
-          sheet_files_index = nr.to_i - 1
+          sheet_files_index = nr.to_i > 0 ? nr.to_i - 1 : 0
           sheet_files_index += 1 if @sheet_files[sheet_files_index]
           @sheet_files[sheet_files_index] = "#{tmpdir}/roo_sheet#{nr.to_i}"
         when /comments([0-9]+).xml$/


### PR DESCRIPTION
Hi - i just came across a weired xlsx where the worksheet xml filenames use zero based numbering:
```
xl/worksheets/sheet0.xml
```

while what you 'normally' see is something like: 

```
xl/worksheets/sheet1.xml
xl/worksheets/sheet2.xml
xl/worksheets/sheet3.xml
```

This pull request contains a v. trivial fix  for this