### PR TITLE
Update the gemspec and reduce the published gems size

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.files.reject! { |fn| fn.include?('test/files') }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri', '~> 1.5'
-  spec.add_dependency 'rubyzip', '~> 1.1', '>= 1.1.7'
+  spec.add_dependency 'nokogiri', '~> 1'
+  spec.add_dependency 'rubyzip', '~> 1.1', '< 2.0.0'
 
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'

--- a/roo.gemspec
+++ b/roo.gemspec
@@ -6,21 +6,20 @@ require 'roo/version'
 Gem::Specification.new do |spec|
   spec.name          = 'roo'
   spec.version       = Roo::VERSION
-  spec.authors       = ['Thomas Preymesser', 'Hugh McGowan', 'Ben Woosley']
-  spec.email         = ['ruby.ruby.ruby.roo@gmail.com']
+  spec.authors       = ['Thomas Preymesser', 'Hugh McGowan', 'Ben Woosley', 'Oleksandr Simonov']
+  spec.email         = ['ruby.ruby.ruby.roo@gmail.com', 'oleksandr@simonov.me']
   spec.summary       = 'Roo can access the contents of various spreadsheet files.'
   spec.description   = "Roo can access the contents of various spreadsheet files. It can handle\n* OpenOffice\n* Excelx\n* LibreOffice\n* CSV"
   spec.homepage      = 'http://github.com/roo-rb/roo'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files.reject! { |fn| fn.include?('test/files') }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri'
-  spec.add_dependency 'rubyzip', '~> 1'
+  spec.add_dependency 'nokogiri', '~> 1.5'
+  spec.add_dependency 'rubyzip', '~> 1.1', '>= 1.1.7'
 
-  spec.add_development_dependency 'rake', '>= 10.0'
-  spec.add_development_dependency 'minitest', '>= 5.4.3'
+  spec.add_development_dependency 'rake', '~> 10.1'
+  spec.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'
 end


### PR DESCRIPTION
+ Removed the spreadsheets in ``test/files`` directory. Gem was reduced from 1.4MB to 63K!
+ Updated authors and email.
+ Removed the executables attribute--it's optional and unnecessary since roo doesn't have any executables.
+ Removed the ``test_files`` spec attribute, which is neither required or optional according to current [RubyGem Specs](http://guides.rubygems.org/specification-reference/).
+ Finally, it doesn't use open-ended dependencies.