### PR TITLE
Update CHANGELOG to reflect v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.0.0beta1] [unreleased]
+## [2.0.0]
 ### Added
 - Added optional support for hidden sheets in Excelx and LibreOffice files [#177](https://github.com/roo-rb/roo/pull/177)
 - Roo::OpenOffice can be used to open encrypted workbooks. [#157](https://github.com/roo-rb/roo/pull/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.0.0]
+## [2.0.0] - 2015-04-24
 ### Added
 - Added optional support for hidden sheets in Excelx and LibreOffice files [#177](https://github.com/roo-rb/roo/pull/177)
 - Roo::OpenOffice can be used to open encrypted workbooks. [#157](https://github.com/roo-rb/roo/pull/157)


### PR DESCRIPTION
we're getting ready to upgrade to `Roo v2.0.0`, psyched, thought this might help others clarify that the gem has been released