### PR TITLE
don't kak on Pathname in excelx, openoffice

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -259,7 +259,7 @@ class Roo::Excelx < Roo::Base
 
     file_type_check(filename,'.xlsx','an Excel-xlsx', file_warning, packed)
 
-    @tmpdir = make_tmpdir(filename.split('/').last, options[:tmpdir_root])
+    @tmpdir = make_tmpdir(File.basename(filename), options[:tmpdir_root])
     @filename = local_filename(filename, @tmpdir, packed)
     @comments_files = []
     @rels_files = []

--- a/lib/roo/open_office.rb
+++ b/lib/roo/open_office.rb
@@ -13,7 +13,7 @@ class Roo::OpenOffice < Roo::Base
 
     @only_visible_sheets = options[:only_visible_sheets]
     file_type_check(filename,'.ods','an Roo::OpenOffice', file_warning, packed)
-    @tmpdir = make_tmpdir(filename.split('/').last, options[:tmpdir_root])
+    @tmpdir = make_tmpdir(File.basename(filename), options[:tmpdir_root])
     @filename = local_filename(filename, @tmpdir, packed)
     #TODO: @cells_read[:default] = false
     Zip::File.open(@filename) do |zip_file|

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -36,6 +36,15 @@ describe Roo::Excelx do
         expect(Roo::Excelx.new(path, cell_max: 100)).to be_a(Roo::Excelx)
       end
     end
+    
+    context 'file path is a Pathname' do
+      let(:path) { Pathname.new('test/files/file_item_error.xlsx') }
+
+      it 'creates an instance' do
+        expect(subject).to be_a(Roo::Excelx)
+      end
+    end
+    
   end
 
   describe '#cell' do

--- a/spec/lib/roo/openoffice_spec.rb
+++ b/spec/lib/roo/openoffice_spec.rb
@@ -9,6 +9,17 @@ describe Roo::OpenOffice do
     it 'creates an instance' do
       expect(subject).to be_a(Roo::OpenOffice)
     end
+
+    context 'file path is a Pathname' do
+      subject do
+        Roo::OpenOffice.new(Pathname.new('test/files/numbers1.ods'))
+      end
+
+      it 'creates an instance' do
+        expect(subject).to be_a(Roo::OpenOffice)
+      end
+    end
+    
   end
 
   # OpenOffice is an alias of LibreOffice. See libreoffice_spec.


### PR DESCRIPTION
the culprit was a use of  filename.split('/').last instead of File.basename(filename). I guess no one has ever used it on windows either (not that they should. use anything on windows).