### PR TITLE
cell_to_csv for double quote escaping changed all tr to gsub

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -663,9 +663,9 @@ class Roo::Base
 
       case celltype(row, col, sheet)
       when :string
-        %("#{onecell.tr('"', '""')}") unless onecell.empty?
+        %("#{onecell.gsub('"', '""')}") unless onecell.empty?
       when :boolean
-        %("#{onecell.tr('"', '""').downcase}")
+        %("#{onecell.gsub('"', '""').downcase}")
       when :float, :percentage
         if onecell == onecell.to_i
           onecell.to_i.to_s
@@ -675,7 +675,7 @@ class Roo::Base
       when :formula
         case onecell
         when String
-          %("#{onecell.tr('"', '""')}") unless onecell.empty?
+          %("#{onecell.gsub('"', '""')}") unless onecell.empty?
         when Float
           if onecell == onecell.to_i
             onecell.to_i.to_s
@@ -692,7 +692,7 @@ class Roo::Base
       when :time
         integer_to_timestring(onecell)
       when :link
-        %("#{onecell.url.tr('"', '""')}")
+        %("#{onecell.url.gsub('"', '""')}")
       else
         fail "unhandled celltype #{celltype(row, col, sheet)}"
       end || ''


### PR DESCRIPTION
As discussed in this issue : 

https://github.com/roo-rb/roo/issues/158

In cell_to_csv tr is not escaping double quote characters correctly, replaced with call to gsub.