### PR TITLE
Offset option for excelx #each_row

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -161,13 +161,16 @@ class Roo::Excelx < Roo::Base
     end
 
     # Yield each row as array of Excelx::Cell objects
-    # accepts options max_rows (int) (offset by 1 for header)
-    # and pad_cells (boolean)
+    # accepts options max_rows (int) (offset by 1 for header),
+    # pad_cells (boolean) and offset (int)
     def each_row(options = {}, &block)
       row_count = 0
+      options[:offset] ||= 0
       @sheet.each_row_streaming do |row|
-        break if options[:max_rows] && row_count == options[:max_rows] + 1
-        block.call(cells_for_row_element(row, options)) if block_given?
+        break if options[:max_rows] && row_count == options[:max_rows] + options[:offset] + 1
+        if block_given? && !(options[:offset] && row_count < options[:offset])
+          block.call(cells_for_row_element(row, options))
+        end
         row_count += 1
       end
     end

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -36,7 +36,7 @@ describe Roo::Excelx do
         expect(Roo::Excelx.new(path, cell_max: 100)).to be_a(Roo::Excelx)
       end
     end
-    
+
     context 'file path is a Pathname' do
       let(:path) { Pathname.new('test/files/file_item_error.xlsx') }
 
@@ -44,7 +44,7 @@ describe Roo::Excelx do
         expect(subject).to be_a(Roo::Excelx)
       end
     end
-    
+
   end
 
   describe '#cell' do
@@ -417,6 +417,33 @@ describe Roo::Excelx do
         end
         # Expect this to get incremented one time more than max (because of the increment at the end of the block)
         # but it should not be near expected_rows.size
+        expect(index).to eq 4
+      end
+    end
+
+    context 'with offset option' do
+      let(:offset) { 3 }
+
+      it 'returns the expected result' do
+        index = 0
+        subject.each_row_streaming(offset: offset) do |row|
+          expect(row.map(&:value)).to eq expected_rows[index + offset]
+          index += 1
+        end
+        expect(index).to eq 11
+      end
+    end
+
+    context 'with offset and max_rows options' do
+      let(:offset) { 3 }
+      let(:max_rows) { 3 }
+
+      it 'returns the expected result' do
+        index = 0
+        subject.each_row_streaming(offset: offset, max_rows: max_rows) do |row|
+          expect(row.map(&:value)).to eq expected_rows[index + offset]
+          index += 1
+        end
         expect(index).to eq 4
       end
     end


### PR DESCRIPTION
I have not found any reference about such ability but can't imagine how are you living without it. So, please, correct me in case if I re-invited wheel.
It can be useful for files with known structure or files with insignificant information on first rows

Thanks