### PR TITLE
Interpret "General" cell types' content as a string

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -52,7 +52,9 @@ class Roo::Excelx < Roo::Base
 
     def to_type(format)
       format = format.to_s.downcase
-      if type = EXCEPTIONAL_FORMATS[format]
+      if format == 'general'
+        :string
+      elsif type = EXCEPTIONAL_FORMATS[format]
         type
       elsif format.include?('#')
         :float


### PR DESCRIPTION
Prevents "General" cells in Excel from being interpreted as strings instead of being parsed into other types. Would close https://github.com/roo-rb/roo/issues/86.