### PR TITLE
Return an enumerator when calling '#each' without a block

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -352,21 +352,25 @@ class Roo::Base
   # control characters and white spaces around columns
 
   def each(options = {})
-    if options.empty?
-      1.upto(last_row) do |line|
-        yield row(line)
+    if block_given?
+      if options.empty?
+        1.upto(last_row) do |line|
+          yield row(line)
+        end
+      else
+        clean_sheet_if_need(options)
+        search_or_set_header(options)
+        headers = @headers ||
+                  Hash[(first_column..last_column).map do |col|
+                    [cell(@header_line, col), col]
+                  end]
+
+        @header_line.upto(last_row) do |line|
+          yield(Hash[headers.map { |k, v| [k, cell(line, v)] }])
+        end
       end
     else
-      clean_sheet_if_need(options)
-      search_or_set_header(options)
-      headers = @headers ||
-                Hash[(first_column..last_column).map do |col|
-                  [cell(@header_line, col), col]
-                end]
-
-      @header_line.upto(last_row) do |line|
-        yield(Hash[headers.map { |k, v| [k, cell(line, v)] }])
-      end
+      to_enum(:each, options)
     end
   end
 

--- a/test/test_generic_spreadsheet.rb
+++ b/test/test_generic_spreadsheet.rb
@@ -94,6 +94,12 @@ class TestBase < Minitest::Test
     assert @oo.instance_variable_get(:@cell).empty?
   end
 
+  def test_each
+    oo_each = @oo.each
+    assert_instance_of Enumerator, oo_each
+    assert_equal [nil, '"Hello world!"', 'dreiundvierzig', 'vierundvierzig', 'fuenfundvierzig', nil, nil], oo_each.to_a.last
+  end
+
   def test_to_yaml
     assert_equal "--- \n" + yaml_entry(5, 1, 'date', '1961-11-21'), @oo.to_yaml({}, 5, 1, 5, 1)
     assert_equal "--- \n" + yaml_entry(8, 3, 'string', 'thisisc8'), @oo.to_yaml({}, 8, 3, 8, 3)


### PR DESCRIPTION
Before this PR, when calling `each` over an spreadsheet would raise an error. 
Now it will return an enumerator over all the rows.