### PR TITLE
Use Excelx::Shared class to pass shared data to Excelx Sheets.

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -112,7 +112,8 @@ module Roo
       end.compact
       @sheets = []
       @sheets_by_name = Hash[@sheet_names.map.with_index do |sheet_name, n|
-        @sheets[n] = Sheet.new(sheet_name, rels_files[n], sheet_files[n], comments_files[n], styles, shared_strings, workbook, sheet_options)
+        # @sheets[n] = Sheet.new(sheet_name, rels_files[n], sheet_files[n], comments_files[n], styles, shared_strings, workbook, sheet_options)
+        @sheets[n] = Sheet.new(sheet_name, @shared, n, sheet_options)
         [sheet_name, @sheets[n]]
       end]
 

--- a/lib/roo/excelx/shared.rb
+++ b/lib/roo/excelx/shared.rb
@@ -1,0 +1,32 @@
+module Roo
+  class Excelx
+    # Public:  Shared class for allowing sheets to share data. This should
+    #          reduce memory usage and reduce the number of objects being passed
+    #          to various inititializers.
+    class Shared
+      attr_accessor :comments_files, :sheet_files, :rels_files
+      def initialize(dir)
+        @dir = dir
+        @comments_files = []
+        @sheet_files = []
+        @rels_files = []
+      end
+
+      def styles
+        @styles ||= Styles.new(File.join(@dir, 'roo_styles.xml'))
+      end
+
+      def shared_strings
+        @shared_strings ||= SharedStrings.new(File.join(@dir, 'roo_sharedStrings.xml'))
+      end
+
+      def workbook
+        @workbook ||= Workbook.new(File.join(@dir, 'roo_workbook.xml'))
+      end
+
+      def base_date
+        workbook.base_date
+      end
+    end
+  end
+end

--- a/lib/roo/excelx/sheet.rb
+++ b/lib/roo/excelx/sheet.rb
@@ -1,12 +1,17 @@
+require 'forwardable'
 module Roo
   class Excelx
     class Sheet
-      def initialize(name, rels_path, sheet_path, comments_path, styles, shared_strings, workbook, options = {})
+      extend Forwardable
+
+      delegate [:styles, :workbook, :shared_strings, :rels_files, :sheet_files, :comments_files] => :@shared
+
+      def initialize(name, shared, sheet_index, options = {})
         @name = name
-        @rels = Relationships.new(rels_path)
-        @comments = Comments.new(comments_path)
-        @styles = styles
-        @sheet = SheetDoc.new(sheet_path, @rels, @styles, shared_strings, workbook, options)
+        @shared = shared
+        @rels = Relationships.new(rels_files[sheet_index])
+        @comments = Comments.new(comments_files[sheet_index])
+        @sheet = SheetDoc.new(sheet_files[sheet_index], @rels, shared, options)
       end
 
       def cells
@@ -65,7 +70,7 @@ module Roo
 
       def excelx_format(key)
         cell = cells[key]
-        @styles.style_format(cell.style).to_s if cell
+        styles.style_format(cell.style).to_s if cell
       end
 
       def hyperlinks


### PR DESCRIPTION
This is part of a larger set of changes I will be introducing to Roo. These changes will address type-casting issues and memory issues like #179. The goal is for these changes to be included in version 2.1.0 of Roo.

This commit has:
+ added the Excelx::Shared class 
+ replaced several instance variables in the Excelx class with Excelx::Shared.
+ modified the arguments for Excelx::Sheet and Excelx::SheetDoc

The next phase will include major changes to Excelx::SheetDoc and Excelx::Cell.

