### PR TITLE
Allow Roo::Excelx to open streams, correctly this time

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -409,19 +409,13 @@ module Roo
       @sheet_files = []
 
       unless is_stream?(zipfilename_or_stream)
-        process_zipfile_entries Zip::File.open(zipfilename_or_stream).to_a.sort_by(&:name)
+        zip_file = Zip::File.open(zipfilename_or_stream)
       else
-        stream = Zip::InputStream.open zipfilename_or_stream
-        begin
-          entries = []
-          while (entry = stream.get_next_entry)
-            entries << entry
-          end
-          process_zipfile_entries entries
-        ensure
-          stream.close
-        end
+        zip_file = Zip::CentralDirectory.new
+        zip_file.read_from_stream zipfilename_or_stream
       end
+
+      process_zipfile_entries zip_file.to_a.sort_by(&:name)
     end
 
     def process_zipfile_entries(entries)

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -2066,7 +2066,7 @@ where the expected result is
 
   def test_open_stream
     return unless EXCELX
-    file_contents = File.read File.join(TESTDIR, fixture_filename(:numbers1, :excelx))
+    file_contents = File.read File.join(TESTDIR, fixture_filename(:numbers1, :excelx)), encoding: 'BINARY'
     stream = StringIO.new(file_contents)
     xlsx = Roo::Excelx.new(stream)
     assert_equal ["Tabelle1","Name of Sheet 2","Sheet3","Sheet4","Sheet5"], xlsx.sheets


### PR DESCRIPTION
It turns out that the approach I used in #209, using `Zip::InputStream`,
doesn't correctly handle certain files, specifically ones created by Numbers
and Google Spreadsheets.  Using `Zip::CentralDirectory` instead handles these
files correctly.