### PR TITLE
Return an enumerator when calling each_row_streaming without a block

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -321,7 +321,12 @@ module Roo
     # Yield an array of Excelx::Cell
     # Takes options for sheet, pad_cells, and max_rows
     def each_row_streaming(options = {})
-      sheet_for(options.delete(:sheet)).each_row(options) { |row| yield row }
+      sheet = sheet_for(options.delete(:sheet))
+      if block_given?
+        sheet.each_row(options) { |row| yield row }
+      else
+        sheet.to_enum(:each_row, options)
+      end
     end
 
     private

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -447,5 +447,11 @@ describe Roo::Excelx do
         expect(index).to eq 4
       end
     end
+
+    context 'without block passed' do
+      it 'returns an enumerator' do
+        expect(subject.each_row_streaming).to be_a(Enumerator)
+      end
+    end
   end
 end


### PR DESCRIPTION
Similar to PR #219 ("Return an enumerator when calling '#each' without a block"), this pull request allows Roo::Excelx#each_row_streaming to return an Enumerator when it's called without a block.

This can be helpful when streaming in very large spreadsheets in batches/slices (e.g. for bulk SQL queries), like this:

```
worksheet.each_row_streaming.each_slice(100) do |rows|
  batch_process rows
end
```