### PR TITLE
Update regexp to check for an url at Spreasheet.open

### DIFF
--- a/lib/roo/spreadsheet.rb
+++ b/lib/roo/spreadsheet.rb
@@ -22,7 +22,7 @@ module Roo
           options[:file_warning] = :ignore
           extension.tr('.', '').downcase.to_sym
         else
-          res = ::File.extname((path =~ ::URI.regexp) ? ::URI.parse(::URI.encode(path)).path : path)
+          res = ::File.extname((path =~ /\A#{::URI.regexp}\z/) ? ::URI.parse(::URI.encode(path)).path : path)
           res.tr('.', '').downcase.to_sym
         end
       end

--- a/spec/lib/roo/spreadsheet_spec.rb
+++ b/spec/lib/roo/spreadsheet_spec.rb
@@ -41,6 +41,17 @@ describe Roo::Spreadsheet do
       end
     end
 
+    context 'for a windows path' do
+      context 'that is xlsx' do
+        let(:filename) { 'c:\Users\Joe\Desktop\myfile.xlsx' }
+
+        it 'loads the proper type' do
+          expect(Roo::Excelx).to receive(:new).with(filename, {})
+          Roo::Spreadsheet.open(filename)
+        end
+      end
+    end
+
     context 'for a csv file' do
       let(:filename) { 'file.csv' }
       let(:options) { { csv_options: { col_sep: '"' } } }


### PR DESCRIPTION
The former regexp checks if the path _contains_ an uri, matching strings that aren't really valid uri's (among other things windows file system locations).