### PR TITLE
Missing Header Raises `Roo::HeaderRowNotFoundError`

### DIFF
--- a/lib/roo.rb
+++ b/lib/roo.rb
@@ -1,4 +1,5 @@
 require 'roo/constants'
+require 'roo/errors'
 require 'roo/spreadsheet'
 require 'roo/base'
 

--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -392,10 +392,10 @@ class Roo::Base
         @header_line = line_no
         return return_headers ? headers : line_no
       elsif line_no > 100
-        fail "Couldn't find header row."
+        raise Roo::HeaderRowNotFoundError
       end
     end
-    fail "Couldn't find header row."
+    raise Roo::HeaderRowNotFoundError
   end
 
   protected

--- a/lib/roo/errors.rb
+++ b/lib/roo/errors.rb
@@ -1,0 +1,9 @@
+module Roo
+  # A base error class for Roo. Most errors thrown by Roo should inherit from
+  # this class.
+  class Error < StandardError; end
+
+  # Raised when Roo cannot find a header row that matches the given column
+  # name(s).
+  class HeaderRowNotFoundError < Error; end
+end

--- a/spec/lib/roo/base_spec.rb
+++ b/spec/lib/roo/base_spec.rb
@@ -41,6 +41,8 @@ describe Roo::Base do
 
   let(:spreadsheet_data) do
     {
+      [3, 1] => 'Header',
+
       [5, 1] => Date.civil(1961, 11, 21),
 
       [8, 3] => 'thisisc8',
@@ -91,7 +93,7 @@ describe Roo::Base do
 
   describe '#first_row' do
     it 'should return the first row' do
-      expect(spreadsheet.first_row).to eq(5)
+      expect(spreadsheet.first_row).to eq(3)
     end
   end
 
@@ -129,6 +131,21 @@ describe Roo::Base do
     it 'should return the specified row' do
       expect(spreadsheet.row(12)).to eq([41.0, 42.0, 43.0, 44.0, 45.0, nil, nil])
       expect(spreadsheet.row(16)).to eq([nil, '"Hello world!"', 'forty-three', 'forty-four', 'forty-five', nil, nil])
+    end
+  end
+
+  describe '#row_with' do
+    context 'with a matching header row' do
+      it 'returns the row number' do
+        expect(spreadsheet.row_with([/Header/])). to eq 3
+      end
+    end
+
+    context 'without a matching header row' do
+      it 'raises an error' do
+        expect { spreadsheet.row_with([/Missing Header/]) }.to \
+          raise_error("Couldn't find header row.")
+      end
     end
   end
 
@@ -185,7 +202,7 @@ describe Roo::Base do
     <<EOS
 ,,,,,,
 ,,,,,,
-,,,,,,
+"Header",,,,,,
 ,,,,,,
 1961-11-21,,,,,,
 ,,,,,,

--- a/spec/lib/roo/base_spec.rb
+++ b/spec/lib/roo/base_spec.rb
@@ -144,7 +144,7 @@ describe Roo::Base do
     context 'without a matching header row' do
       it 'raises an error' do
         expect { spreadsheet.row_with([/Missing Header/]) }.to \
-          raise_error("Couldn't find header row.")
+          raise_error(Roo::HeaderRowNotFoundError)
       end
     end
   end

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -82,7 +82,7 @@ describe Roo::Excelx do
               this: 'This',
               that: 'That'
             )
-          end.to raise_error("Couldn't find header row.")
+          end.to raise_error(Roo::HeaderRowNotFoundError)
         end
       end
     end


### PR DESCRIPTION
Currently, Roo raises a generic `RuntimeError` with the message
"Couldn't find header row" when a matching header row is not found.

This behavior makes it difficult to rescue from the most specific error
desired, because `RuntimeError` is the default error class for `raise`.

Additionally, because Roo does not have its own library-level error
class from which all errors inherit, it is difficult to differentiate
Roo library errors from errors caused by the developer / user.

From the [Ruby documentation][1]:

> It is recommended that a library should have one subclass of
> `StandardError` or `RuntimeError` and have specific exception types
> inherit from it. This allows the user to rescue a generic exception
> type to catch all exceptions the library may raise even if future
> versions of the library add new exception subclasses.

This commit adds a generic `Roo::Error` class which inherits from
`StandardError` and a specific `Roo::HeaderRowNotFound` class that is
raised when a matching header row could not be found.

In the future, additional subclasses of `Roo::Error` can be added in
order to allow users to more easily rescue the correct errors.

Note: This is *not* a backwards-compatible change. Users who currently
rescue `RuntimeError` for a missing header row will now see an error
raised.

[1]: http://ruby-doc.org/core-2.2.2/Exception.html