### PR TITLE
Extract `ExceedsMaxError` as `TooManyCellsError`

### DIFF
--- a/lib/roo/errors.rb
+++ b/lib/roo/errors.rb
@@ -6,4 +6,7 @@ module Roo
   # Raised when Roo cannot find a header row that matches the given column
   # name(s).
   class HeaderRowNotFoundError < Error; end
+
+  # Raised when a spreadsheet has too many cells.
+  class TooManyCellsError < Error; end
 end

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -75,8 +75,6 @@ module Roo
       module_function :to_type
     end
 
-    ExceedsMaxError = Class.new(StandardError)
-
     # initialization and opening of a spreadsheet file
     # values for packed: :zip
     # optional cell_max (int) parameter for early aborting attempts to parse
@@ -112,7 +110,10 @@ module Roo
 
       if cell_max
         cell_count = ::Roo::Utils.num_cells_in_range(sheet_for(options.delete(:sheet)).dimensions)
-        raise ExceedsMaxError.new("Excel file exceeds cell maximum: #{cell_count} > #{cell_max}") if cell_count > cell_max
+        if cell_count > cell_max
+          raise Roo::TooManyCellsError,
+            "File has #{cell_count} cells; maximum allowed was #{cell_max}."
+        end
       end
 
       super

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -25,7 +25,8 @@ describe Roo::Excelx do
       let(:path) { 'test/files/only_one_sheet.xlsx' }
 
       it 'raises an appropriate error' do
-        expect { Roo::Excelx.new(path, cell_max: 1) }.to raise_error(Roo::Excelx::ExceedsMaxError)
+        expect { Roo::Excelx.new(path, cell_max: 1) }.to \
+          raise_error(Roo::TooManyCellsError)
       end
     end
 


### PR DESCRIPTION
As a follow-up to df53d9a55a7a1936a84c3ea22b6dfa7ef6487d94, this commit
extracts `Roo::Excelx::ExceedsMaxError` into a class that inherits from
`Roo::Error`.

The new class is renamed as `Roo::TooManyCellsError` in order to clarify
which maximum is being exceeded.