### PR TITLE
#N/A errors work

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -14,6 +14,8 @@ module Roo
         end
 
         def create_numeric(number)
+          return number if number == '#N/A'
+
           case @format
           when /%/
             Float(number)
@@ -25,6 +27,8 @@ module Roo
         end
 
         def formatted_value
+          return @cell_value if @cell_value == '#N/A'
+
           formatter = formats[@format]
           if formatter.is_a? Proc
             formatter.call(@cell_value)

--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -2,6 +2,8 @@ module Roo
   class Excelx
     class Cell
       class Number < Cell::Base
+        ERROR_VALUES = %w(#N/A #REF! #NAME? #DIV/0! #NULL! #VALUE! #NUM!)
+
         attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
 
         def initialize(value, formula, excelx_type, style, link, coordinate)
@@ -14,7 +16,7 @@ module Roo
         end
 
         def create_numeric(number)
-          return number if number == '#N/A'
+          return number if ERROR_VALUES.include?(number)
 
           case @format
           when /%/
@@ -27,7 +29,7 @@ module Roo
         end
 
         def formatted_value
-          return @cell_value if @cell_value == '#N/A'
+          return @cell_value if ERROR_VALUES.include?(@cell_value)
 
           formatter = formats[@format]
           if formatter.is_a? Proc

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -34,10 +34,12 @@ class TestRooExcelxCellNumber < Minitest::Test
     end
   end
 
-  def test_n_a_number
-    cell = Roo::Excelx::Cell::Number.new '#N/A', nil, ['General'], nil, nil, nil
-    assert_equal '#N/A', cell.value
-    assert_equal '#N/A', cell.formatted_value
+  def test_numbers_with_cell_errors
+    %w(#N/A #REF! #NAME? #DIV/0! #NULL! #VALUE! #NUM!).each do |error|
+      cell = Roo::Excelx::Cell::Number.new error, nil, ['General'], nil, nil, nil
+      assert_equal error, cell.value
+      assert_equal error, cell.formatted_value
+    end
   end
 
   def test_formats

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -34,6 +34,12 @@ class TestRooExcelxCellNumber < Minitest::Test
     end
   end
 
+  def test_n_a_number
+    cell = Roo::Excelx::Cell::Number.new '#N/A', nil, ['General'], nil, nil, nil
+    assert_equal '#N/A', cell.value
+    assert_equal '#N/A', cell.formatted_value
+  end
+
   def test_formats
     [
       ['General', '1042'],


### PR DESCRIPTION
#269 revealed a bug when dealing with error fields like '#N/A'. This is a temporary fix for that particular error. It's possible that others will encounter a similar issue with other errors.

The more permanent fix should include a Cell::Error class specifically for errors like '#N/A' '#DIV/0', etc.

One issue That needs to be investigated before a more permanent solution to this issue is if error cells are always interpreted as number cells or if they might be interpreted as another cell type.