### PR TITLE
move `ERROR_VALUES` from Excelx::Cell::Number ~> Excelx

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -6,7 +6,10 @@ require 'forwardable'
 
 module Roo
   class Excelx < Roo::Base
+    require 'set'
     extend Forwardable
+
+    ERROR_VALUES = %w(#N/A #REF! #NAME? #DIV/0! #NULL! #VALUE! #NUM!).to_set
 
     require 'roo/excelx/shared'
     require 'roo/excelx/workbook'

--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -2,8 +2,6 @@ module Roo
   class Excelx
     class Cell
       class Number < Cell::Base
-        ERROR_VALUES = %w(#N/A #REF! #NAME? #DIV/0! #NULL! #VALUE! #NUM!)
-
         attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
 
         def initialize(value, formula, excelx_type, style, link, coordinate)
@@ -16,7 +14,7 @@ module Roo
         end
 
         def create_numeric(number)
-          return number if ERROR_VALUES.include?(number)
+          return number if Excelx::ERROR_VALUES.include?(number)
 
           case @format
           when /%/
@@ -29,7 +27,7 @@ module Roo
         end
 
         def formatted_value
-          return @cell_value if ERROR_VALUES.include?(@cell_value)
+          return @cell_value if Excelx::ERROR_VALUES.include?(@cell_value)
 
           formatter = formats[@format]
           if formatter.is_a? Proc

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -6,6 +6,18 @@ describe Roo::Excelx do
     Roo::Excelx.new(path)
   end
 
+  describe 'Constants' do
+    describe 'ERROR_VALUES' do
+      it 'returns all possible errorr values' do
+        expect(described_class::ERROR_VALUES).to eq(%w(#N/A #REF! #NAME? #DIV/0! #NULL! #VALUE! #NUM!).to_set)
+      end
+
+      it 'is a set' do
+        expect(described_class::ERROR_VALUES).to be_an_instance_of(Set)
+      end
+    end
+  end
+
   describe '.new' do
     let(:path) { 'test/files/numeric-link.xlsx' }
 

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -35,7 +35,7 @@ class TestRooExcelxCellNumber < Minitest::Test
   end
 
   def test_numbers_with_cell_errors
-    %w(#N/A #REF! #NAME? #DIV/0! #NULL! #VALUE! #NUM!).each do |error|
+    Excels::ERROR_VALUES.each do |error|
       cell = Roo::Excelx::Cell::Number.new error, nil, ['General'], nil, nil, nil
       assert_equal error, cell.value
       assert_equal error, cell.formatted_value


### PR DESCRIPTION
```
intialize ERROR_VALUES as `Set` for performace impact
added test cases
```

@stevendaniels: As per our discussion on [commit](https://github.com/roo-rb/roo/commit/fe7af777c821bdb9dccb023f63fd1e1cc842fd62), I created this PR.