### PR TITLE
Handle url with long query params (ex. S3 secure url)

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -535,6 +535,16 @@ class Roo::Base
     initialize(@filename)
   end
 
+  def find_basename(filename)
+    if uri?(filename)
+      require 'uri'
+      uri = URI::parse filename
+      File.basename(uri.path)
+    elsif !is_stream?(filename)
+      File.basename(filename)
+    end
+  end
+
   def make_tmpdir(prefix = nil, root = nil, &block)
     prefix = "#{TEMP_PREFIX}#{prefix}"
 
@@ -599,7 +609,7 @@ class Roo::Base
 
   def download_uri(uri, tmpdir)
     require 'open-uri'
-    tempfilename = File.join(tmpdir, File.basename(uri))
+    tempfilename = File.join(tmpdir, find_basename(uri))
     begin
       File.open(tempfilename, 'wb') do |file|
         open(uri, 'User-Agent' => "Ruby/#{RUBY_VERSION}") do |net|

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -39,7 +39,7 @@ module Roo
 
       unless is_stream?(filename_or_stream)
         file_type_check(filename_or_stream, %w[.xlsx .xlsm], 'an Excel 2007', file_warning, packed)
-        basename = File.basename(filename_or_stream)
+        basename = find_basename(filename_or_stream)
       end
 
       @tmpdir = make_tmpdir(basename, options[:tmpdir_root])

--- a/lib/roo/open_office.rb
+++ b/lib/roo/open_office.rb
@@ -19,7 +19,7 @@ module Roo
 
       @only_visible_sheets = options[:only_visible_sheets]
       file_type_check(filename, '.ods', 'an Roo::OpenOffice', file_warning, packed)
-      @tmpdir   = make_tmpdir(File.basename(filename), options[:tmpdir_root])
+      @tmpdir   = make_tmpdir(find_basename(filename), options[:tmpdir_root])
       @filename = local_filename(filename, @tmpdir, packed)
       # TODO: @cells_read[:default] = false
       open_oo_file(options)


### PR DESCRIPTION
When you have a really long url with query params, you get this error message:

```
"File name too long @ dir_s_mkdir - /tmp/roo_Mate%CC%81riaux.xlsx?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJ4PG27V6H4DDKG3Q%2F20160218%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160218T215714Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=37ca8bd46c24e289ef7aa742be23617de4b70ce56fbc457415a73b7c56226c7f20160218-1164-7230qc"
```
This fix makes sure to ignore the query params part.
