### PR TITLE
Recognize floating point numbers with a leading sign

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -21,7 +21,7 @@ module Roo
           when /\.0/
             Float(number)
           else
-            (number.include?('.') || (/\A\d+E[-+]\d+\z/i =~ number)) ? Float(number) : Integer(number)
+            (number.include?('.') || (/\A[-+]?\d+E[-+]\d+\z/i =~ number)) ? Float(number) : Integer(number)
           end
         end
 


### PR DESCRIPTION
Fixes things like 'invalid value for Integer(): "-1E-4"'