### PR TITLE
Update Roo::Utils.number_to_letter

### DIFF
--- a/lib/roo/utils.rb
+++ b/lib/roo/utils.rb
@@ -2,6 +2,8 @@ module Roo
   module Utils
     extend self
 
+    LETTERS = ("A".."Z").to_a
+
     def split_coordinate(str)
       @split_coordinate ||= {}
 
@@ -27,16 +29,14 @@ module Roo
 
     # convert a number to something like 'AB' (1 => 'A', 2 => 'B', ...)
     def number_to_letter(num)
-      results = []
-      num = num.to_i
+      result = ""
 
-      while (num > 0)
-        mod = (num - 1) % 26
-        results = [(65 + mod).chr] + results
-        num = ((num - mod) / 26)
+      until num.zero?
+        num, index = (num - 1).divmod(26)
+        result.prepend(LETTERS[index])
       end
 
-      results.join
+      result
     end
 
     def letter_to_number(letters)

--- a/lib/roo/utils.rb
+++ b/lib/roo/utils.rb
@@ -2,7 +2,7 @@ module Roo
   module Utils
     extend self
 
-    LETTERS = ("A".."Z").to_a
+    LETTERS = ('A'..'Z').to_a
 
     def split_coordinate(str)
       @split_coordinate ||= {}

--- a/spec/lib/roo/utils_spec.rb
+++ b/spec/lib/roo/utils_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ::Roo::Utils do
   subject { described_class }
 
   context '#number_to_letter' do
-    ('A'..'Z').to_a.each_with_index do |letter, index|
+    described_class::LETTERS.each_with_index do |letter, index|
       it "should return '#{ letter }' when passed #{ index + 1 }" do
         expect(described_class.number_to_letter(index + 1)).to eq(letter)
       end


### PR DESCRIPTION
Update Roo::Utils.number_to_letter method.

MemoryProfiler results (N = 1..10000):
before:
```ruby
Total allocated: 5602640 bytes (107816 objects)

allocated memory by gem
-----------------------------------
   5602640  roo/lib

allocated memory by file
-----------------------------------
   5602640  .../roo/lib/roo/utils.rb

allocated memory by location
-----------------------------------
   3512640  .../roo/lib/roo/utils.rb:35
   1690000  .../roo/lib/roo/utils.rb:39
    400000  .../roo/lib/roo/utils.rb:30
```

after:
```ruby
Total allocated: 1570880 bytes (39272 objects)

allocated memory by gem
-----------------------------------
   1570880  roo-new/lib

allocated memory by file
-----------------------------------
   1570880  .../roo-new/lib/roo/utils.rb

allocated memory by location
-----------------------------------
   1170880  .../roo-new/lib/roo/utils.rb:35
    400000  .../roo-new/lib/roo/utils.rb:32
```

Benchmark results (N = 1..2000000):
```ruby
Rehearsal ----------------------------------------------------------
OLD number_to_letter:    5.100000   0.000000   5.100000 (  5.111661)
NEW number_to_letter:    2.910000   0.000000   2.910000 (  2.913276)
------------------------------------------------- total: 8.010000sec

                             user     system      total        real
OLD number_to_letter:    5.020000   0.010000   5.030000 (  5.026673)
NEW number_to_letter:    2.890000   0.000000   2.890000 (  2.895102)
```
