### PR TITLE
streaming without hyperlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- Discard hiperlinks lookups to allow streaming parsing without loading whole files
+
 ## [2.4.0] 2016-05-14
 ### Fixed  
 - Fixed opening spreadsheets with charts [315](https://github.com/roo-rb/roo/pull/315)

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -36,6 +36,7 @@ module Roo
       cell_max = options.delete(:cell_max)
       sheet_options = {}
       sheet_options[:expand_merged_ranges] = (options[:expand_merged_ranges] || false)
+      sheet_options[:no_hyperlinks] = (options[:no_hyperlinks] || false)
 
       unless is_stream?(filename_or_stream)
         file_type_check(filename_or_stream, %w[.xlsx .xlsm], 'an Excel 2007', file_warning, packed)

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -39,8 +39,13 @@ module Roo
       def each_cell(row_xml)
         return [] unless row_xml
         row_xml.children.each do |cell_element|
-          key = ::Roo::Utils.ref_to_key(cell_element['r'])
-          yield cell_from_xml(cell_element, hyperlinks(@relationships)[key])
+          # If you're sure you're not going to need this hyperlinks you can discard it
+          hyperlinks = unless @options[:no_hyperlinks]
+                         key = ::Roo::Utils.ref_to_key(cell_element['r'])
+                         hyperlinks(@relationships)[key]
+                       end
+
+          yield cell_from_xml(cell_element, hyperlinks)
         end
       end
 


### PR DESCRIPTION
Hi guys,

While using roo to parse xlsm files and using the `each_row_streaming` iteration we realized that a lot of memory consumption is due to the code related with the hyperlinks.

I'm not sure what the hyperlinks are maybe someone can explain to us, but we ended doing is adding an option where you can disable that part of code that in our case we don't need to get the data that we finally ingest from the excel files. Sorry but I cannot share the excel file here came from one of our customers.

Do you think this can be useful for other people? So it can be merge in the main repository and released as a new version.

If you need something else like some metrics processing the files, to add documentation in the README about that option, adding some specs about it usage. Just let me know I'll be glad to address all of that to get merged. We'll be easier for us to use the gem that keep updating with this our fork

Thanks in advance