### PR TITLE
Parse sheets in ODS files once (to improve performance)

### DIFF
--- a/lib/roo/open_office.rb
+++ b/lib/roo/open_office.rb
@@ -25,6 +25,18 @@ module Roo
       open_oo_file(options)
       super(filename, options)
       initialize_default_variables
+
+      unless @table_display.any?
+        doc.xpath(XPATH_FIND_TABLE_STYLES).each do |style|
+          read_table_styles(style)
+        end
+      end
+
+      @sheet_names = doc.xpath(XPATH_LOCAL_NAME_TABLE).map do |sheet|
+        if !@only_visible_sheets || @table_display[attribute(sheet, 'style-name')]
+          sheet.attributes['name'].value
+        end
+      end.compact
     rescue => e # clean up any temp files, but only if an error was raised
       close
       raise e
@@ -132,16 +144,7 @@ module Roo
     end
 
     def sheets
-      unless @table_display.any?
-        doc.xpath(XPATH_FIND_TABLE_STYLES).each do |style|
-          read_table_styles(style)
-        end
-      end
-      doc.xpath(XPATH_LOCAL_NAME_TABLE).map do |sheet|
-        if !@only_visible_sheets || @table_display[attribute(sheet, 'style-name')]
-          sheet.attributes['name'].value
-        end
-      end.compact
+      @sheet_names
     end
 
     # version of the Roo::OpenOffice document


### PR DESCRIPTION
This improves the performance greatly for large files because instead of parsing the sheets every time a cell is accessed, this commit moves the parsing to the constructor.

In my tests with a 60K line ODS spreadsheet this change resulted in running times around ~70 seconds. Before this change the processing was not finished after having run for 10-20 minutes. Others are reporting > 4 hours of processing here: https://github.com/roo-rb/roo/issues/113.

I am not sure who the active maintainer is but I'll just ping you, @stevendaniels, to start with 😄 