### PR TITLE
Improve the xlsx cell parsing

### DIFF
--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -90,10 +90,9 @@ module Roo
         cell_xml.children.each do |cell|
           case cell.name
           when 'is'
-            cell.children.each do |inline_str|
-              if inline_str.name == 't'
-                return Excelx::Cell.create_cell(:string, inline_str.content, formula, style, hyperlink, coordinate)
-              end
+            content_arr = cell.search('t').map(&:content)
+            unless content_arr.empty?
+              return Excelx::Cell.create_cell(:string, content_arr.join(''), formula, style, hyperlink, coordinate)
             end
           when 'f'
             formula = cell.content

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -101,6 +101,8 @@ module Roo
             return create_cell_from_value(value_type, cell, formula, format, style, hyperlink, base_date, coordinate)
           end
         end
+
+        Excelx::Cell::Empty.new(coordinate)
       end
 
       def create_cell_from_value(value_type, cell, formula, format, style, hyperlink, base_date, coordinate)

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -17,6 +17,8 @@
 # with the wrong spreadsheet class
 #STDERR.reopen "/dev/null","w"
 
+Encoding.default_external = "UTF-8"
+
 require 'test_helper'
 require 'stringio'
 


### PR DESCRIPTION
In case if all children are unknown => return an empty cell
If a cell has a nested styles(http://officeopenxml.com/SSstyles.php) -> collect "t" children and return the total string

PS. spec failed on MacOs 10.11 + Ruby 2.2.4 without `default_external ` "ArgumentError: invalid byte sequence in US-ASCII"