### PR TITLE
Updates to improve Roo's memory usage

### DIFF
--- a/lib/roo/excelx/extractor.rb
+++ b/lib/roo/excelx/extractor.rb
@@ -8,7 +8,6 @@ module Roo
       private
 
       def doc
-        @doc ||=
         if doc_exists?
           ::Roo::Utils.load_xml(@path).remove_namespaces!
         end

--- a/lib/roo/excelx/shared_strings.rb
+++ b/lib/roo/excelx/shared_strings.rb
@@ -3,6 +3,14 @@ require 'roo/excelx/extractor'
 module Roo
   class Excelx
     class SharedStrings < Excelx::Extractor
+
+      COMMON_STRINGS = {
+        t: "t",
+        r: "r",
+        html_tag_open: "<html>",
+        html_tag_closed: "</html>"
+      }
+
       def [](index)
         to_a[index]
       end
@@ -26,18 +34,17 @@ module Roo
       def fix_invalid_shared_strings(doc)
         invalid = { '_x000D_'  => "\n" }
         xml = doc.to_s
+        return doc unless xml[/#{invalid.keys.join('|')}/]
 
-        if xml[/#{invalid.keys.join('|')}/]
-          @doc = ::Nokogiri::XML(xml.gsub(/#{invalid.keys.join('|')}/, invalid))
-        end
+        ::Nokogiri::XML(xml.gsub(/#{invalid.keys.join('|')}/, invalid))
       end
 
       def extract_shared_strings
         return [] unless doc_exists?
 
-        fix_invalid_shared_strings(doc)
+        document = fix_invalid_shared_strings(doc)
         # read the shared strings xml document
-        doc.xpath('/sst/si').map do |si|
+        document.xpath('/sst/si').map do |si|
           shared_string = ''
           si.children.each do |elem|
             case elem.name

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -157,8 +157,9 @@ module Roo
       end
 
       def extract_hyperlinks(relationships)
-        # FIXME: select the valid hyperlinks and then map those.
-        Hash[doc.xpath('/worksheet/hyperlinks/hyperlink').map do |hyperlink|
+        return {} unless (hyperlinks = doc.xpath('/worksheet/hyperlinks/hyperlink'))
+
+        Hash[hyperlinks.map do |hyperlink|
           if hyperlink.attribute('id') && (relationship = relationships[hyperlink.attribute('id').text])
             [::Roo::Utils.ref_to_key(hyperlink.attributes['ref'].to_s), relationship.attribute('Target').text]
           end


### PR DESCRIPTION
+ Updated `Roo::Excelx::Extractor#doc`: removed caching to improve memory usage.
This allows for the XML parsed by Nokogiri to be released properly. These
changes will result in Roo being slower in some use cases (Style extraction is
slower), but the memory savings are worth it.

```
retained memory by gem
-----------------------------------
   7743534  roo/lib
   4815870  nokogiri-1.6.8
      1167  rubyzip-1.2.0
       504  other
       289  2.2.2/lib

```

```
retained memory by gem
-----------------------------------
   7743686  roo/lib
      1678  nokogiri-1.6.8
      1163  rubyzip-1.2.0
       504  other
       289  2.2.2/lib
```

+ Updated `Roo::Excelx::SheetDoc#extract_hyperlinks`