### PR TITLE
Roo::Base#close should release memory

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -42,6 +42,11 @@ class Roo::Base
     if self.class.respond_to?(:finalize_tempdirs)
       self.class.finalize_tempdirs(object_id)
     end
+
+    instance_variables.each do |instance_variable|
+      instance_variable_set(instance_variable, nil)
+    end
+
     nil
   end
 


### PR DESCRIPTION
- Updated `Roo::Base#close` to improve memory usage.

Previously, the close method just cleaned up the temporary folders created. Now,
it also unsets all instance variables, allowing previously retained memory to
be released.

This is a breaking change from before, now, trying to access the Roo object after
using the `close` method will cause errors.

Before:

```
retained memory by gem
-----------------------------------
   7743686  roo/lib
      1678  nokogiri-1.6.8
      1163  rubyzip-1.2.0
       504  other
       289  2.2.2/lib
```

After: 

```
retained memory by gem
-----------------------------------
   1959160  roo/lib
       681  rubyzip-1.2.0
       444  nokogiri-1.6.8
        80  2.2.2/lib
```
