### PR TITLE
Fix NameError: uninitialized constant Roo::Base::TEMP_PREFIX

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -545,7 +545,7 @@ class Roo::Base
 
   def make_tmpdir(prefix = nil, root = nil, &block)
     warn '[DEPRECATION] extend Roo::Tempdir and use its .make_tempdir instead'
-    prefix = "#{TEMP_PREFIX}#{prefix}"
+    prefix = "#{Roo::TEMP_PREFIX}#{prefix}"
     root ||= ENV['ROO_TMP']
 
     if block_given?


### PR DESCRIPTION
It causes NameError: uninitialized constant Roo::Base::TEMP_PREFIX.