### PR TITLE
Added support for loading remote files over ftp

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -605,7 +605,7 @@ class Roo::Base
   end
 
   def uri?(filename)
-    filename.start_with?('http://', 'https://')
+    filename.start_with?('http://', 'https://', 'ftp://')
   rescue
     false
   end


### PR DESCRIPTION
Roo uses open-uri to load remote files. Open-uri can download files over both http and ftp, however, roo was short-circuiting this and only loading open-uri if the uri started with "http://" or "https://". I've modified this check to also allow "ftp://" uris to be loaded.

It would have been nice to do this more dynamically, by "asking" open-uri what protocols it supports, but there doesn't seem to be a way to do this in open-uri at present.