### PR TITLE
Fix Ruby 2.4.0 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.2.4
   - 2.3.1
+  - 2.4.0
   - ruby-head
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   # additional testing libs
   gem 'webmock'
   gem 'shoulda'
-  gem 'activesupport', '< 5.0.0'
+  gem 'activesupport', '< 5.1'
   gem 'rspec', '>= 3.0.0'
   gem 'vcr'
   gem 'simplecov', '>= 0.9.0', require: false

--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -183,7 +183,7 @@ class Roo::Base
     options = (args.last.is_a?(Hash) ? args.pop : {})
 
     case args[0]
-    when Fixnum
+    when Integer
       find_by_row(args[0])
     when :all
       find_by_conditions(options)
@@ -225,7 +225,7 @@ class Roo::Base
 
   def cell_type_by_value(value)
     case value
-    when Fixnum then :float
+    when Integer then :float
     when String, Float then :string
     else
       fail ArgumentError, "Type for #{value} not set"
@@ -590,7 +590,7 @@ class Roo::Base
   # converts cell coordinate to numeric values of row,col
   def normalize(row, col)
     if row.is_a?(::String)
-      if col.is_a?(::Fixnum)
+      if col.is_a?(::Integer)
         # ('A',1):
         # ('B', 5) -> (5, 2)
         row, col = col, row
@@ -646,7 +646,7 @@ class Roo::Base
     case sheet
     when nil
       fail ArgumentError, "Error: sheet 'nil' not valid"
-    when Fixnum
+    when Integer
       sheets.fetch(sheet - 1) do
         fail RangeError, "sheet index #{sheet} not found"
       end
@@ -714,7 +714,7 @@ class Roo::Base
       case onecell
       when String
         %("#{onecell.gsub('"', '""')}") unless onecell.empty?
-      when Fixnum
+      when Integer
         onecell.to_s
       when Float
         if onecell == onecell.to_i

--- a/spec/lib/roo/openoffice_spec.rb
+++ b/spec/lib/roo/openoffice_spec.rb
@@ -13,10 +13,10 @@ describe Roo::OpenOffice do
     context 'for float/integer values' do
       context 'integer without point' do
         it { expect(subject.cell(3,"A","Sheet4")).to eq(1234) }
-        it { expect(subject.cell(3,"A","Sheet4")).to be_a(Fixnum) }
+        it { expect(subject.cell(3,"A","Sheet4")).to be_a(Integer) }
       end
 
-      context 'float with point' do 
+      context 'float with point' do
         it { expect(subject.cell(3,"B","Sheet4")).to eq(1234.00) }
         it { expect(subject.cell(3,"B","Sheet4")).to be_a(Float) }
       end

--- a/test/excelx/cell/test_time.rb
+++ b/test/excelx/cell/test_time.rb
@@ -25,6 +25,6 @@ class TestRooExcelxCellTime < Minitest::Test
 
   def test_value
     cell = time.new('0.0751', nil, [:numeric_or_formula, 'h:mm'], 6, nil, base_date, nil)
-    assert_kind_of Fixnum, cell.value
+    assert_kind_of Integer, cell.value
   end
 end

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -1056,14 +1056,14 @@ Sheet 3:
   def test_bug_to_xml_with_empty_sheets
     with_each_spreadsheet(:name=>'emptysheets', :format=>[:openoffice, :excelx]) do |oo|
       oo.sheets.each { |sheet|
-        assert_equal nil, oo.first_row, "first_row not nil in sheet #{sheet}"
-        assert_equal nil, oo.last_row, "last_row not nil in sheet #{sheet}"
-        assert_equal nil, oo.first_column, "first_column not nil in sheet #{sheet}"
-        assert_equal nil, oo.last_column, "last_column not nil in sheet #{sheet}"
-        assert_equal nil, oo.first_row(sheet), "first_row not nil in sheet #{sheet}"
-        assert_equal nil, oo.last_row(sheet), "last_row not nil in sheet #{sheet}"
-        assert_equal nil, oo.first_column(sheet), "first_column not nil in sheet #{sheet}"
-        assert_equal nil, oo.last_column(sheet), "last_column not nil in sheet #{sheet}"
+        assert_nil oo.first_row, "first_row not nil in sheet #{sheet}"
+        assert_nil oo.last_row, "last_row not nil in sheet #{sheet}"
+        assert_nil oo.first_column, "first_column not nil in sheet #{sheet}"
+        assert_nil oo.last_column, "last_column not nil in sheet #{sheet}"
+        assert_nil oo.first_row(sheet), "first_row not nil in sheet #{sheet}"
+        assert_nil oo.last_row(sheet), "last_row not nil in sheet #{sheet}"
+        assert_nil oo.first_column(sheet), "first_column not nil in sheet #{sheet}"
+        assert_nil oo.last_column(sheet), "last_column not nil in sheet #{sheet}"
       }
       oo.to_xml
     end


### PR DESCRIPTION
Removes fixnum deprecations and `assert_nil` warnings when running the tests.