### PR TITLE
Raise an error Roo::Excelx::Extractor document is missing

### DIFF
--- a/lib/roo/errors.rb
+++ b/lib/roo/errors.rb
@@ -6,4 +6,6 @@ module Roo
   # Raised when Roo cannot find a header row that matches the given column
   # name(s).
   class HeaderRowNotFoundError < Error; end
+
+  class FileNotFound < Error; end
 end

--- a/lib/roo/excelx/extractor.rb
+++ b/lib/roo/excelx/extractor.rb
@@ -8,9 +8,9 @@ module Roo
       private
 
       def doc
-        if doc_exists?
-          ::Roo::Utils.load_xml(@path).remove_namespaces!
-        end
+        raise FileNotFound, "#{@path} file not found" unless doc_exists?
+
+        ::Roo::Utils.load_xml(@path).remove_namespaces!
       end
 
       def doc_exists?


### PR DESCRIPTION
Adds a more explicit error for #344