### PR TITLE
Refactored test cases into separate classes and modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ Roo's public methods have stayed relatively consistent between 1.13.x and 2.0.0,
 Roo uses Minitest and RSpec. The best of both worlds! Run `bundle exec rake` to
 run the tests/examples.
 
+You can run the tests/examples with Rspec like reporters by running
+`USE_REPORTERS=true bundle exec rake`
+
 Roo also has a few tests that take a long time (5+ seconds). To run these, use
 `LONG_RUN=true bundle exec rake`
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,5 @@ require 'helpers'
 RSpec.configure do |c|
   c.include Helpers
   c.color = true
-  c.formatter = :documentation
+  c.formatter = :documentation if ENV["USE_REPORTERS"]
 end

--- a/test/files/expected_results/bbu_info.txt
+++ b/test/files/expected_results/bbu_info.txt
@@ -1,0 +1,12 @@
+File: bbu%s
+Number of sheets: 3
+Sheets: 2007_12, Tabelle2, Tabelle3
+Sheet 1:
+  First row: 1
+  Last row: 4
+  First column: A
+  Last column: F
+Sheet 2:
+  - empty -
+Sheet 3:
+  - empty -

--- a/test/files/expected_results/numbers_info.yml
+++ b/test/files/expected_results/numbers_info.yml
@@ -1,0 +1,28 @@
+File: numbers1%s
+Number of sheets: 5
+Sheets: Tabelle1, Name of Sheet 2, Sheet3, Sheet4, Sheet5
+Sheet 1:
+  First row: 1
+  Last row: 18
+  First column: A
+  Last column: G
+Sheet 2:
+  First row: 5
+  Last row: 14
+  First column: B
+  Last column: E
+Sheet 3:
+  First row: 1
+  Last row: 1
+  First column: A
+  Last column: BA
+Sheet 4:
+  First row: 1
+  Last row: 1
+  First column: A
+  Last column: E
+Sheet 5:
+  First row: 1
+  Last row: 6
+  First column: A
+  Last column: E

--- a/test/formatters/test_csv.rb
+++ b/test/formatters/test_csv.rb
@@ -44,7 +44,7 @@ class TestRooFormatterCSV < Minitest::Test
   # wird.
   # Besser: Methode um temporaeres Dir. portabel zu bestimmen
   def test_huge_document_to_csv
-    skip unless ENV["LONG_RUN"]
+    skip_long_test
 
     original_csv_path = File.join(TESTDIR, "Bibelbund.csv")
     with_each_spreadsheet(name: "Bibelbund", format: [:openoffice, :excelx]) do |workbook|
@@ -71,7 +71,7 @@ class TestRooFormatterCSV < Minitest::Test
   end
 
   def test_bug_quotes_excelx
-    skip unless ENV["LONG_RUN"]
+    skip_long_test
     # TODO: run this test with a much smaller document
     with_each_spreadsheet(name: "Bibelbund", format: [:openoffice, :excelx]) do |workbook|
       workbook.default_sheet = workbook.sheets.first

--- a/test/helpers/test_accessing_files.rb
+++ b/test/helpers/test_accessing_files.rb
@@ -1,0 +1,60 @@
+# Tests for "Accessing Files" which includes opening and closing files.
+module TestAccesingFiles
+  def test_close
+    with_each_spreadsheet(name: "numbers1") do |oo|
+      next unless (tempdir = oo.instance_variable_get("@tmpdir"))
+      oo.close
+      refute File.exist?(tempdir), "Expected #{tempdir} to be cleaned up"
+    end
+  end
+
+  # NOTE: Ruby 2.4.0 changed the way GC works. The last Roo object created by
+  #       with_each_spreadsheet wasn't getting GC'd until after the process
+  #       ended.
+  #
+  #       That behavior change broke this test. In order to fix it, I forked the
+  #       process and passed the temp directories from the forked process in
+  #       order to check if they were removed properly.
+  def test_finalize
+    skip if defined? JRUBY_VERSION
+
+    read, write = IO.pipe
+    pid = Process.fork do
+      with_each_spreadsheet(name: "numbers1") do |oo|
+        write.puts oo.instance_variable_get("@tmpdir")
+      end
+    end
+
+    Process.wait(pid)
+    write.close
+    tempdirs = read.read.split("\n")
+    read.close
+
+    refute tempdirs.empty?
+    tempdirs.each do |tempdir|
+      refute File.exist?(tempdir), "Expected #{tempdir} to be cleaned up"
+    end
+  end
+
+  def test_cleanup_on_error
+    # NOTE: This test was occasionally failing because when it started running
+    #       other tests would have already added folders to the temp directory,
+    #       polluting the directory. You'd end up in a situation where there
+    #       would be less folders AFTER this ran than originally started.
+    #
+    #       Instead, just use a custom temp directory to test the functionality.
+    ENV["ROO_TMP"] = Dir.tmpdir + "/test_cleanup_on_error"
+    Dir.mkdir(ENV["ROO_TMP"]) unless File.exist?(ENV["ROO_TMP"])
+    expected_dir_contents = Dir.open(ENV["ROO_TMP"]).to_a
+    with_each_spreadsheet(name: "non_existent_file", ignore_errors: true) {}
+
+    assert_equal expected_dir_contents, Dir.open(ENV["ROO_TMP"]).to_a
+    Dir.rmdir ENV["ROO_TMP"] if File.exist?(ENV["ROO_TMP"])
+    ENV.delete "ROO_TMP"
+  end
+
+  def test_name_with_leading_slash
+    xlsx = Roo::Excelx.new(File.join(TESTDIR, "/name_with_leading_slash.xlsx"))
+    assert_equal 1, xlsx.sheets.count
+  end
+end

--- a/test/helpers/test_comments.rb
+++ b/test/helpers/test_comments.rb
@@ -1,0 +1,43 @@
+module TestComments
+  def test_comment
+    options = { name: "comments", format: [:openoffice, :libreoffice, :excelx] }
+    with_each_spreadsheet(options) do |oo|
+      assert_equal "Kommentar fuer B4", oo.comment("b", 4)
+      assert_equal "Kommentar fuer B5", oo.comment("b", 5)
+    end
+  end
+
+  def test_no_comment
+    options = { name: "comments", format: [:openoffice, :excelx] }
+    with_each_spreadsheet(options) do |oo|
+      # There are no comments at the second sheet.
+      assert_nil oo.comment("b", 4, oo.sheets[1])
+    end
+  end
+
+  def test_comments
+    options = { name: "comments", format: [:openoffice, :libreoffice, :excelx] }
+    expexted_comments = [
+      [4, 2, "Kommentar fuer B4"],
+      [5, 2, "Kommentar fuer B5"],
+    ]
+
+    with_each_spreadsheet(options) do |oo|
+      assert_equal expexted_comments, oo.comments(oo.sheets.first), "comments error in class #{oo.class}"
+    end
+  end
+
+  def test_empty_sheet_comments
+    options = { name: "emptysheets", format: [:openoffice, :excelx] }
+    with_each_spreadsheet(options) do |oo|
+      assert_equal [], oo.comments, "An empty sheet's formulas should be an empty array"
+    end
+  end
+
+  def test_comments_from_google_sheet_exported_as_xlsx
+    expected_comments = [[1, 1, "this is a comment\n\t-Steven Daniels"]]
+    with_each_spreadsheet(name: "comments-google", format: [:excelx]) do |oo|
+      assert_equal expected_comments, oo.comments(oo.sheets.first), "comments error in class #{oo.class}"
+    end
+  end
+end

--- a/test/helpers/test_formulas.rb
+++ b/test/helpers/test_formulas.rb
@@ -1,0 +1,9 @@
+module TestFormulas
+  def test_empty_sheet_formulas
+    options = { name: "emptysheets", format: [:openoffice, :excelx] }
+    with_each_spreadsheet(options) do |oo|
+      oo.default_sheet = oo.sheets.first
+      assert_equal [], oo.formulas, "An empty sheet's formulas should be an empty array"
+    end
+  end
+end

--- a/test/helpers/test_labels.rb
+++ b/test/helpers/test_labels.rb
@@ -1,0 +1,103 @@
+module TestLabels
+  def test_labels
+    options = { name: "named_cells", format: [:openoffice, :excelx, :libreoffice] }
+    expected_labels = [
+      ["anton", [5, 3, "Sheet1"]],
+      ["berta", [4, 2, "Sheet1"]],
+      ["caesar", [7, 2, "Sheet1"]],
+    ]
+    with_each_spreadsheet(options) do |oo|
+      assert_equal expected_labels, oo.labels, "error with labels array in class #{oo.class}"
+    end
+  end
+
+  def test_labeled_cells
+    options = { name: "named_cells", format: [:openoffice, :excelx, :libreoffice] }
+    with_each_spreadsheet(options) do |oo|
+      oo.default_sheet = oo.sheets.first
+      begin
+        row, col = oo.label("anton")
+      rescue ArgumentError
+        puts "labels error at #{oo.class}"
+        raise
+      end
+      assert_equal 5, row
+      assert_equal 3, col
+
+      row, col = oo.label("anton")
+      assert_equal "Anton", oo.cell(row, col)
+
+      row, col = oo.label("berta")
+      assert_equal "Bertha", oo.cell(row, col)
+
+      row, col = oo.label("caesar")
+      assert_equal "Cäsar", oo.cell(row, col)
+
+      row, col = oo.label("never")
+      assert_nil row
+      assert_nil col
+
+      row, col, sheet = oo.label("anton")
+      assert_equal 5, row
+      assert_equal 3, col
+      assert_equal "Sheet1", sheet
+
+      assert_equal "Anton", oo.anton
+      assert_raises(NoMethodError) do
+        row, col = oo.never
+      end
+
+      # Reihenfolge row, col,sheet analog zu #label
+      expected_labels = [
+        ["anton", [5, 3, "Sheet1"]],
+        ["berta", [4, 2, "Sheet1"]],
+        ["caesar", [7, 2, "Sheet1"]],
+      ]
+      assert_equal expected_labels, oo.labels, "error with labels array in class #{oo.class}"
+    end
+  end
+
+  def test_label
+    options = { name: "named_cells", format: [:openoffice, :excelx, :libreoffice] }
+    with_each_spreadsheet(options) do |oo|
+      begin
+        row, col = oo.label("anton")
+      rescue ArgumentError
+        puts "labels error at #{oo.class}"
+        raise
+      end
+
+      assert_equal 5, row, "error with label in class #{oo.class}"
+      assert_equal 3, col, "error with label in class #{oo.class}"
+
+      row, col = oo.label("anton")
+      assert_equal "Anton", oo.cell(row, col), "error with label in class #{oo.class}"
+
+      row, col = oo.label("berta")
+      assert_equal "Bertha", oo.cell(row, col), "error with label in class #{oo.class}"
+
+      row, col = oo.label("caesar")
+      assert_equal "Cäsar", oo.cell(row, col), "error with label in class #{oo.class}"
+
+      row, col = oo.label("never")
+      assert_nil row
+      assert_nil col
+
+      row, col, sheet = oo.label("anton")
+      assert_equal 5, row
+      assert_equal 3, col
+      assert_equal "Sheet1", sheet
+    end
+  end
+
+  def test_method_missing_anton
+    options = { name: "named_cells", format: [:openoffice, :excelx, :libreoffice] }
+    with_each_spreadsheet(options) do |oo|
+      # oo.default_sheet = oo.sheets.first
+      assert_equal "Anton", oo.anton
+      assert_raises(NoMethodError) do
+        oo.never
+      end
+    end
+  end
+end

--- a/test/helpers/test_sheets.rb
+++ b/test/helpers/test_sheets.rb
@@ -1,0 +1,55 @@
+# NOTE: Putting these tests into modules in order to share them across different
+#       test classes, i.e. both TestRooExcelx and TestRooOpenOffice should run
+#       sheet related tests.
+#
+#       This will allow me to reuse these test cases when I add new classes for
+#       Roo's future API.
+# Sheet related tests
+module TestSheets
+  def test_sheets
+    sheet_names = ["Tabelle1", "Name of Sheet 2", "Sheet3", "Sheet4", "Sheet5"]
+    with_each_spreadsheet(name: "numbers1") do |oo|
+      assert_equal sheet_names, oo.sheets
+      assert_raises(RangeError) { oo.default_sheet = "no_sheet" }
+      assert_raises(TypeError)  { oo.default_sheet = [1, 2, 3] }
+      oo.sheets.each do |sheet_name|
+        oo.default_sheet = sheet_name
+        assert_equal sheet_name, oo.default_sheet
+      end
+    end
+  end
+
+  def test_sheetname
+    bad_sheet_name = "non existing sheet name"
+    with_each_spreadsheet(name: "numbers1") do |oo|
+      oo.default_sheet = "Name of Sheet 2"
+      assert_equal "I am sheet 2", oo.cell("C", 5)
+      assert_raises(RangeError) { oo.default_sheet = bad_sheet_name }
+      assert_raises(RangeError) { oo.default_sheet = bad_sheet_name }
+      assert_raises(RangeError) { oo.cell("C", 5, bad_sheet_name) }
+      assert_raises(RangeError) { oo.celltype("C", 5, bad_sheet_name) }
+      assert_raises(RangeError) { oo.empty?("C", 5, bad_sheet_name) }
+      assert_raises(RangeError) { oo.formula?("C", 5, bad_sheet_name) }
+      assert_raises(RangeError) { oo.formula("C", 5, bad_sheet_name) }
+      assert_raises(RangeError) { oo.set("C", 5, 42, bad_sheet_name) }
+      assert_raises(RangeError) { oo.formulas(bad_sheet_name) }
+      assert_raises(RangeError) { oo.to_yaml({}, 1, 1, 1, 1, bad_sheet_name) }
+    end
+  end
+
+  def test_info_doesnt_set_default_sheet
+    sheet_name = "Sheet3"
+    with_each_spreadsheet(name: "numbers1") do |oo|
+      oo.default_sheet = sheet_name
+      oo.info
+      assert_equal sheet_name, oo.default_sheet
+    end
+  end
+
+  def test_bug_numbered_sheet_names
+    options = { name: "bug-numbered-sheet-names", format: :excelx }
+    with_each_spreadsheet(options) do |oo|
+      oo.each_with_pagename {}
+    end
+  end
+end

--- a/test/helpers/test_styles.rb
+++ b/test/helpers/test_styles.rb
@@ -1,0 +1,62 @@
+module TestStyles
+  def test_cell_styles
+    # styles only valid in excel spreadsheets?
+    # TODO: what todo with other spreadsheet types
+    with_each_spreadsheet(name: "style", format: [:excelx]) do |oo|
+      # bold
+      assert_equal true, oo.font(1, 1).bold?
+      assert_equal false, oo.font(1, 1).italic?
+      assert_equal false, oo.font(1, 1).underline?
+
+      # italic
+      assert_equal false, oo.font(2, 1).bold?
+      assert_equal true, oo.font(2, 1).italic?
+      assert_equal false, oo.font(2, 1).underline?
+
+      # normal
+      assert_equal false, oo.font(3, 1).bold?
+      assert_equal false, oo.font(3, 1).italic?
+      assert_equal false, oo.font(3, 1).underline?
+
+      # underline
+      assert_equal false, oo.font(4, 1).bold?
+      assert_equal false, oo.font(4, 1).italic?
+      assert_equal true, oo.font(4, 1).underline?
+
+      # bold italic
+      assert_equal true, oo.font(5, 1).bold?
+      assert_equal true, oo.font(5, 1).italic?
+      assert_equal false, oo.font(5, 1).underline?
+
+      # bold underline
+      assert_equal true, oo.font(6, 1).bold?
+      assert_equal false, oo.font(6, 1).italic?
+      assert_equal true, oo.font(6, 1).underline?
+
+      # italic underline
+      assert_equal false, oo.font(7, 1).bold?
+      assert_equal true, oo.font(7, 1).italic?
+      assert_equal true, oo.font(7, 1).underline?
+
+      # bolded row
+      assert_equal true, oo.font(8, 1).bold?
+      assert_equal false, oo.font(8, 1).italic?
+      assert_equal false, oo.font(8, 1).underline?
+
+      # bolded col
+      assert_equal true, oo.font(9, 2).bold?
+      assert_equal false, oo.font(9, 2).italic?
+      assert_equal false, oo.font(9, 2).underline?
+
+      # bolded row, italic col
+      assert_equal true, oo.font(10, 3).bold?
+      assert_equal true, oo.font(10, 3).italic?
+      assert_equal false, oo.font(10, 3).underline?
+
+      # normal
+      assert_equal false, oo.font(11, 4).bold?
+      assert_equal false, oo.font(11, 4).italic?
+      assert_equal false, oo.font(11, 4).underline?
+    end
+  end
+end

--- a/test/roo/test_base.rb
+++ b/test/roo/test_base.rb
@@ -1,0 +1,182 @@
+require "test_helper"
+
+class TestRooBase < Minitest::Test
+  def test_info
+    # NOTE: unfortunately, the ods and xlsx versions of numbers1 are not
+    #       identical, so this test fails for Open Office.
+    expected_templ = File.read("#{TESTDIR}/expected_results/numbers_info.yml")
+    with_each_spreadsheet(name: "numbers1", format: [:excelx]) do |workbook|
+      ext = get_extension(workbook)
+      expected = Kernel.format(expected_templ, ext)
+      assert_equal expected.strip, workbook.info.strip
+    end
+  end
+
+  def test_column
+    with_each_spreadsheet(name: "numbers1") do |workbook|
+      expected = [1.0, 5.0, nil, 10.0, Date.new(1961, 11, 21), "tata", nil, nil, nil, nil, "thisisa11", 41.0, nil, nil, 41.0, "einundvierzig", nil, Date.new(2007, 5, 31)]
+      assert_equal expected, workbook.column(1)
+      assert_equal expected, workbook.column("a")
+    end
+  end
+
+  def test_column_huge_document
+    skip_long_test
+    with_each_spreadsheet(name: "Bibelbund", format: [:openoffice, :excelx]) do |workbook|
+      workbook.default_sheet = workbook.sheets.first
+      assert_equal 3735, workbook.column("a").size
+    end
+  end
+
+  def test_simple_spreadsheet_find_by_condition
+    with_each_spreadsheet(name: "simple_spreadsheet") do |workbook|
+      workbook.header_line = 3
+      results = workbook.find(:all, conditions: { "Comment" => "Task 1" })
+      assert_equal Date.new(2007, 05, 07), results[1]["Date"]
+      assert_equal 10.75, results[1]["Start time"]
+      assert_equal 12.50, results[1]["End time"]
+      assert_equal 0, results[1]["Pause"]
+      assert_equal 1.75, results[1]["Sum"]
+      assert_equal "Task 1", results[1]["Comment"]
+    end
+  end
+
+  def test_bug_bbu
+    expected_templ = File.read("#{TESTDIR}/expected_results/bbu_info.txt")
+    with_each_spreadsheet(name: "bbu", format: [:openoffice, :excelx]) do |workbook|
+      ext = get_extension(workbook)
+      expected_result = Kernel.format(expected_templ, ext)
+      assert_equal expected_result.strip, workbook.info.strip
+
+      workbook.default_sheet = workbook.sheets[1] # empty sheet
+      assert_nil workbook.first_row
+      assert_nil workbook.last_row
+      assert_nil workbook.first_column
+      assert_nil workbook.last_column
+    end
+  end
+
+  def test_find_by_row_huge_document
+    skip_long_test
+    options = { name: "Bibelbund", format: [:openoffice, :excelx] }
+    with_each_spreadsheet(options) do |workbook|
+      workbook.default_sheet = workbook.sheets.first
+      result = workbook.find 20
+      assert result
+      assert_equal "Brief aus dem Sekretariat", result[0]["TITEL"]
+
+      result = workbook.find 22
+      assert result
+      assert_equal "Brief aus dem Skretariat. Tagung in Amberg/Opf.", result[0]["TITEL"]
+    end
+  end
+
+  def test_find_by_row
+    with_each_spreadsheet(name: "numbers1") do |workbook|
+      workbook.header_line = nil
+      result = workbook.find 16
+      assert result
+      assert_nil workbook.header_line
+      # keine Headerlines in diesem Beispiel definiert
+      assert_equal "einundvierzig", result[0]
+      # assert_equal false, results
+      result = workbook.find 15
+      assert result
+      assert_equal 41, result[0]
+    end
+  end
+
+  def test_find_by_row_if_header_line_is_not_nil
+    with_each_spreadsheet(name: "numbers1") do |workbook|
+      workbook.header_line = 2
+      refute_nil workbook.header_line
+      results = workbook.find 1
+      assert results
+      assert_equal 5, results[0]
+      assert_equal 6, results[1]
+      results = workbook.find 15
+      assert results
+      assert_equal "einundvierzig", results[0]
+    end
+  end
+
+  def test_find_by_conditions
+    skip_long_test
+    expected_results = [
+      {
+        "VERFASSER" => "Almassy, Annelene von",
+        "INTERNET" => nil,
+        "SEITE" => 316.0,
+        "KENNUNG" => "Aus dem Bibelbund",
+        "OBJEKT" => "Bibel+Gem",
+        "PC" => "#C:\\Bibelbund\\reprint\\BuG1982-3.pdf#",
+        "NUMMER" => "1982-3",
+        "TITEL" => "Brief aus dem Sekretariat"
+      },
+      {
+        "VERFASSER" => "Almassy, Annelene von",
+        "INTERNET" => nil,
+        "SEITE" => 222.0,
+        "KENNUNG" => "Aus dem Bibelbund",
+        "OBJEKT" => "Bibel+Gem",
+        "PC" => "#C:\\Bibelbund\\reprint\\BuG1983-2.pdf#",
+        "NUMMER" => "1983-2",
+        "TITEL" => "Brief aus dem Sekretariat"
+      }
+    ]
+
+    expected_results_size = 2
+    options = { name: "Bibelbund", format: [:openoffice, :excelx] }
+    with_each_spreadsheet(options) do |workbook|
+      results = workbook.find(:all, conditions: { "TITEL" => "Brief aus dem Sekretariat" })
+      assert_equal expected_results_size, results.size
+      assert_equal expected_results, results
+
+      conditions = {
+        "TITEL" => "Brief aus dem Sekretariat",
+        "VERFASSER" => "Almassy, Annelene von"
+      }
+      results = workbook.find(:all, conditions: conditions)
+      assert_equal expected_results, results
+      assert_equal expected_results_size, results.size
+
+      results = workbook.find(:all, conditions: { "VERFASSER" => "Almassy, Annelene von" })
+      assert_equal 13, results.size
+    end
+  end
+
+  def test_find_by_conditions_with_array_option
+    expected_results = [
+      [
+        "Brief aus dem Sekretariat",
+        "Almassy, Annelene von",
+        "Bibel+Gem",
+        "1982-3",
+        316.0,
+        nil,
+        "#C:\\Bibelbund\\reprint\\BuG1982-3.pdf#",
+        "Aus dem Bibelbund",
+      ],
+      [
+        "Brief aus dem Sekretariat",
+        "Almassy, Annelene von",
+        "Bibel+Gem",
+        "1983-2",
+        222.0,
+        nil,
+        "#C:\\Bibelbund\\reprint\\BuG1983-2.pdf#",
+        "Aus dem Bibelbund",
+      ]
+    ]
+    options = { name: "Bibelbund", format: [:openoffice, :excelx] }
+    with_each_spreadsheet(options) do |workbook|
+      conditions = {
+        "TITEL" => "Brief aus dem Sekretariat",
+        "VERFASSER" => "Almassy, Annelene von"
+      }
+      results = workbook.find(:all, conditions: conditions, array: true)
+      assert_equal 2, results.size
+      assert_equal expected_results, results
+    end
+  end
+end

--- a/test/roo/test_csv.rb
+++ b/test/roo/test_csv.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class TestRooCSV < Minitest::Test
   def test_sheets

--- a/test/roo/test_excelx.rb
+++ b/test/roo/test_excelx.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class TestRooExcelx < Minitest::Test
+class TestRworkbookExcelx < Minitest::Test
   def test_download_uri_with_invalid_host
     assert_raises(RuntimeError) do
       Roo::Excelx.new("http://example.com/file.xlsx")
@@ -20,20 +20,20 @@ class TestRooExcelx < Minitest::Test
 
   def test_should_raise_file_not_found_error
     assert_raises(IOError) do
-      Roo::Excelx.new(File.join("testnichtvorhanden", "Bibelbund.xlsx"))
+      roo_class.new(File.join("testnichtvorhanden", "Bibelbund.xlsx"))
     end
   end
 
   def test_file_warning_default
-    assert_raises(TypeError) { Roo::Excelx.new(File.join(TESTDIR, "numbers1.ods")) }
-    assert_raises(TypeError) { Roo::Excelx.new(File.join(TESTDIR, "numbers1.xls")) }
+    assert_raises(TypeError) { roo_class.new(File.join(TESTDIR, "numbers1.ods")) }
+    assert_raises(TypeError) { roo_class.new(File.join(TESTDIR, "numbers1.xls")) }
   end
 
   def test_file_warning_error
     %w(ods xls).each do |extension|
       assert_raises(TypeError) do
         options = { packed: false, file_warning: :error }
-        Roo::Excelx.new(File.join(TESTDIR, "numbers1. #{extension}"), options)
+        roo_class.new(File.join(TESTDIR, "numbers1. #{extension}"), options)
       end
     end
   end
@@ -41,13 +41,13 @@ class TestRooExcelx < Minitest::Test
   def test_file_warning_warning
     options = { packed: false, file_warning: :warning }
     assert_raises(ArgumentError) do
-      Roo::Excelx.new(File.join(TESTDIR, "numbers1.ods"), options)
+      roo_class.new(File.join(TESTDIR, "numbers1.ods"), options)
     end
   end
 
   def test_file_warning_ignore
     options = { packed: false, file_warning: :ignore }
-    sheet = Roo::Excelx.new(File.join(TESTDIR, "type_excelx.ods"), options)
+    sheet = roo_class.new(File.join(TESTDIR, "type_excelx.ods"), options)
     assert sheet, "Should not throw an error"
   end
 
@@ -66,13 +66,13 @@ class TestRooExcelx < Minitest::Test
     # where the expected result is
     # "A: TestString"
     # "B: TestString"
-    xlsx = Roo::Excelx.new(File.join(TESTDIR, "formula_string_error.xlsx"))
+    xlsx = roo_class.new(File.join(TESTDIR, "formula_string_error.xlsx"))
     assert_equal "Teststring", xlsx.cell("a", 1)
     assert_equal "Teststring", xlsx.cell("a", 2)
   end
 
   def test_parsing_xslx_from_numbers
-    xlsx = Roo::Excelx.new(File.join(TESTDIR, "numbers-export.xlsx"))
+    xlsx = roo_class.new(File.join(TESTDIR, "numbers-export.xlsx"))
 
     xlsx.default_sheet = xlsx.sheets.first
     assert_equal "Sheet 1", xlsx.cell("a", 1)
@@ -100,7 +100,7 @@ class TestRooExcelx < Minitest::Test
 
   def test_expand_merged_range
     options = { expand_merged_ranges: true }
-    xlsx = Roo::Excelx.new(File.join(TESTDIR, "merged_ranges.xlsx"), options)
+    xlsx = roo_class.new(File.join(TESTDIR, "merged_ranges.xlsx"), options)
 
     [
       {
@@ -134,7 +134,7 @@ class TestRooExcelx < Minitest::Test
   end
 
   def test_noexpand_merged_range
-    xlsx = Roo::Excelx.new(File.join(TESTDIR, "merged_ranges.xlsx"))
+    xlsx = roo_class.new(File.join(TESTDIR, "merged_ranges.xlsx"))
 
     [
       {
@@ -171,13 +171,13 @@ class TestRooExcelx < Minitest::Test
     file = filename(:numbers1)
     file_contents = File.read File.join(TESTDIR, file), encoding: "BINARY"
     stream = StringIO.new(file_contents)
-    xlsx = Roo::Excelx.new(stream)
+    xlsx = roo_class.new(stream)
     expected_sheet_names = ["Tabelle1", "Name of Sheet 2", "Sheet3", "Sheet4", "Sheet5"]
     assert_equal expected_sheet_names, xlsx.sheets
   end
 
   def test_header_offset
-    xlsx = Roo::Excelx.new(File.join(TESTDIR, "header_offset.xlsx"))
+    xlsx = roo_class.new(File.join(TESTDIR, "header_offset.xlsx"))
     data = xlsx.parse(column_1: "Header A1", column_2: "Header B1")
     assert_equal "Data A2", data[0][:column_1]
     assert_equal "Data B2", data[0][:column_2]
@@ -208,6 +208,110 @@ class TestRooExcelx < Minitest::Test
       assert_equal "41", workbook.cell("A", 16)
       workbook.set("A", 17, 42.5)
       assert_equal 42.5, workbook.cell("A", 17)
+    end
+  end
+
+  # TODO: temporaerer Test
+  def test_seiten_als_date
+    skip_long_test
+
+    with_each_spreadsheet(name: "Bibelbund", format: :excelx) do |workbook|
+      assert_equal "Bericht aus dem Sekretariat", workbook.cell(13, 1)
+      assert_equal "1981-4", workbook.cell(13, "D")
+      assert_equal String, workbook.excelx_type(13, "E")[1].class
+      assert_equal [:numeric_or_formula, "General"], workbook.excelx_type(13, "E")
+      assert_equal "428", workbook.excelx_value(13, "E")
+      assert_equal 428.0, workbook.cell(13, "E")
+    end
+  end
+
+  def test_bug_simple_spreadsheet_time_bug
+    # really a bug? are cells really of type time?
+    # No! :float must be the correct type
+    with_each_spreadsheet(name: "simple_spreadsheet", format: :excelx) do |workbook|
+      # puts workbook.cell("B", 5).to_s
+      # assert_equal :time, workbook.celltype("B", 5)
+      assert_equal :float, workbook.celltype("B", 5)
+      assert_equal 10.75, workbook.cell("B", 5)
+      assert_equal 12.50, workbook.cell("C", 5)
+      assert_equal 0, workbook.cell("D", 5)
+      assert_equal 1.75, workbook.cell("E", 5)
+      assert_equal "Task 1", workbook.cell("F", 5)
+      assert_equal Date.new(2007, 5, 7), workbook.cell("A", 5)
+    end
+  end
+
+  def test_simple2_excelx
+    with_each_spreadsheet(name: "simple_spreadsheet", format: :excelx) do |workbook|
+      assert_equal [:numeric_or_formula, "yyyy\\-mm\\-dd"], workbook.excelx_type("A", 4)
+      assert_equal [:numeric_or_formula, "#,##0.00"], workbook.excelx_type("B", 4)
+      assert_equal [:numeric_or_formula, "#,##0.00"], workbook.excelx_type("c", 4)
+      assert_equal [:numeric_or_formula, "General"], workbook.excelx_type("d", 4)
+      assert_equal [:numeric_or_formula, "General"], workbook.excelx_type("e", 4)
+      assert_equal :string, workbook.excelx_type("f", 4)
+
+      assert_equal "39209", workbook.excelx_value("a", 4)
+      assert_equal "yyyy\\-mm\\-dd", workbook.excelx_format("a", 4)
+      assert_equal "9.25", workbook.excelx_value("b", 4)
+      assert_equal "10.25", workbook.excelx_value("c", 4)
+      assert_equal "0", workbook.excelx_value("d", 4)
+      # ... Sum-Spalte
+      # assert_equal "Task 1", workbook.excelx_value("f", 4)
+      assert_equal "Task 1", workbook.cell("f", 4)
+      assert_equal Date.new(2007, 05, 07), workbook.cell("a", 4)
+      assert_equal "9.25", workbook.excelx_value("b", 4)
+      assert_equal "#,##0.00", workbook.excelx_format("b", 4)
+      assert_equal 9.25, workbook.cell("b", 4)
+      assert_equal :float, workbook.celltype("b", 4)
+      assert_equal :float, workbook.celltype("d", 4)
+      assert_equal 0, workbook.cell("d", 4)
+      assert_equal :formula, workbook.celltype("e", 4)
+      assert_equal 1, workbook.cell("e", 4)
+      assert_equal "C4-B4-D4", workbook.formula("e", 4)
+      assert_equal :string, workbook.celltype("f", 4)
+      assert_equal "Task 1", workbook.cell("f", 4)
+    end
+  end
+
+  def test_bug_pfand_from_windows_phone_xlsx
+    # skip_jruby_incompatible_test
+    # TODO: Does JRUBY need to skip this test
+    return if defined? JRUBY_VERSION
+
+    options = { name: "Pfand_from_windows_phone", format: :excelx }
+    with_each_spreadsheet(options) do |workbook|
+      workbook.default_sheet = workbook.sheets.first
+      assert_equal ["Blatt1", "Blatt2", "Blatt3"], workbook.sheets
+      assert_equal "Summe", workbook.cell("b", 1)
+
+      assert_equal Date.new(2011, 9, 14), workbook.cell("a", 2)
+      assert_equal :date, workbook.celltype("a", 2)
+      assert_equal Date.new(2011, 9, 15), workbook.cell("a", 3)
+      assert_equal :date, workbook.celltype("a", 3)
+
+      assert_equal 3.81, workbook.cell("b", 2)
+      assert_equal "SUM(C2:L2)", workbook.formula("b", 2)
+      assert_equal 0.7, workbook.cell("c", 2)
+    end # each
+  end
+
+  def test_excelx_links
+    with_each_spreadsheet(name: "link", format: :excelx) do |workbook|
+      assert_equal "Google", workbook.cell(1, 1)
+      assert_equal "http://www.google.com", workbook.cell(1, 1).href
+    end
+  end
+
+  # Excel has two base date formats one from 1900 and the other from 1904.
+  # see #test_base_dates_in_excel
+  def test_base_dates_in_excelx
+    with_each_spreadsheet(name: "1900_base", format: :excelx) do |workbook|
+      assert_equal Date.new(2009, 06, 15), workbook.cell(1, 1)
+      assert_equal :date, workbook.celltype(1, 1)
+    end
+    with_each_spreadsheet(name: "1904_base", format: :excelx) do |workbook|
+      assert_equal Date.new(2009, 06, 15), workbook.cell(1, 1)
+      assert_equal :date, workbook.celltype(1, 1)
     end
   end
 

--- a/test/roo/test_open_office.rb
+++ b/test/roo/test_open_office.rb
@@ -8,8 +8,8 @@ class TestRooOpenOffice < Minitest::Test
     start_local_server(file, port) do
       url = "#{local_server(port)}/#{file}"
 
-      oo = roo_class.new(url, packed: :zip)
-      assert_in_delta 0.001, 505.14, oo.cell("c", 33).to_f
+      workbook = roo_class.new(url, packed: :zip)
+      assert_in_delta 0.001, 505.14, workbook.cell("c", 33).to_f
     end
   end
 
@@ -30,9 +30,9 @@ class TestRooOpenOffice < Minitest::Test
   end
 
   def test_openoffice_zipped
-    oo = roo_class.new(File.join(TESTDIR, "bode-v1.ods.zip"), packed: :zip)
-    assert oo
-    assert_equal 'ist "e" im Nenner von H(s)', oo.cell("b", 5)
+    workbook = roo_class.new(File.join(TESTDIR, "bode-v1.ods.zip"), packed: :zip)
+    assert workbook
+    assert_equal 'ist "e" im Nenner von H(s)', workbook.cell("b", 5)
   end
 
   def test_should_raise_file_not_found_error
@@ -77,8 +77,8 @@ class TestRooOpenOffice < Minitest::Test
   end
 
   def test_encrypted_file
-    oo = roo_class.new(File.join(TESTDIR, "encrypted-letmein.ods"), password: "letmein")
-    assert_equal "Hello World", oo.cell("a", 1)
+    workbook = roo_class.new(File.join(TESTDIR, "encrypted-letmein.ods"), password: "letmein")
+    assert_equal "Hello World", workbook.cell("a", 1)
   end
 
   def test_encrypted_file_requires_password
@@ -114,13 +114,168 @@ class TestRooOpenOffice < Minitest::Test
     assert_equal expected_formulas, workbook.formulas
   end
 
-  def test_header_with_brackets_oo
+  def test_header_with_brackets_open_office
     options = { name: "advanced_header", format: :openoffice }
     with_each_spreadsheet(options) do |workbook|
       parsed_head = workbook.parse(headers: true)
       assert_equal "Date(yyyy-mm-dd)", workbook.cell("A", 1)
       assert_equal parsed_head[0].keys, ["Date(yyyy-mm-dd)"]
       assert_equal parsed_head[0].values, ["Date(yyyy-mm-dd)"]
+    end
+  end
+
+  def test_office_version
+    with_each_spreadsheet(name: "numbers1", format: :openoffice) do |workbook|
+      assert_equal "1.0", workbook.officeversion
+    end
+  end
+
+  def test_bug_contiguous_cells
+    with_each_spreadsheet(name: "numbers1", format: :openoffice) do |workbook|
+      workbook.default_sheet = "Sheet4"
+      assert_equal Date.new(2007, 06, 16), workbook.cell("a", 1)
+      assert_equal 10, workbook.cell("b", 1)
+      assert_equal 10, workbook.cell("c", 1)
+      assert_equal 10, workbook.cell("d", 1)
+      assert_equal 10, workbook.cell("e", 1)
+    end
+  end
+
+  def test_italo_table
+    with_each_spreadsheet(name: "simple_spreadsheet_from_italo", format: :openoffice) do |workbook|
+      assert_equal  "1", workbook.cell("A", 1)
+      assert_equal  "1", workbook.cell("B", 1)
+      assert_equal  "1", workbook.cell("C", 1)
+      assert_equal  1, workbook.cell("A", 2).to_i
+      assert_equal  2, workbook.cell("B", 2).to_i
+      assert_equal  1, workbook.cell("C", 2).to_i
+      assert_equal  1, workbook.cell("A", 3)
+      assert_equal  3, workbook.cell("B", 3)
+      assert_equal  1, workbook.cell("C", 3)
+      assert_equal  "A", workbook.cell("A", 4)
+      assert_equal  "A", workbook.cell("B", 4)
+      assert_equal  "A", workbook.cell("C", 4)
+      assert_equal  0.01, workbook.cell("A", 5)
+      assert_equal  0.01, workbook.cell("B", 5)
+      assert_equal  0.01, workbook.cell("C", 5)
+      assert_equal 0.03, workbook.cell("a", 5) + workbook.cell("b", 5) + workbook.cell("c", 5)
+
+      # Cells values in row 1:
+      assert_equal "1:string", [workbook.cell(1, 1), workbook.celltype(1, 1)].join(":")
+      assert_equal "1:string", [workbook.cell(1, 2), workbook.celltype(1, 2)].join(":")
+      assert_equal "1:string", [workbook.cell(1, 3), workbook.celltype(1, 3)].join(":")
+
+      # Cells values in row 2:
+      assert_equal "1:string", [workbook.cell(2, 1), workbook.celltype(2, 1)].join(":")
+      assert_equal "2:string", [workbook.cell(2, 2), workbook.celltype(2, 2)].join(":")
+      assert_equal "1:string", [workbook.cell(2, 3), workbook.celltype(2, 3)].join(":")
+
+      # Cells values in row 3:
+      assert_equal "1:float", [workbook.cell(3, 1), workbook.celltype(3, 1)].join(":")
+      assert_equal "3:float", [workbook.cell(3, 2), workbook.celltype(3, 2)].join(":")
+      assert_equal "1:float", [workbook.cell(3, 3), workbook.celltype(3, 3)].join(":")
+
+      # Cells values in row 4:
+      assert_equal "A:string", [workbook.cell(4, 1), workbook.celltype(4, 1)].join(":")
+      assert_equal "A:string", [workbook.cell(4, 2), workbook.celltype(4, 2)].join(":")
+      assert_equal "A:string", [workbook.cell(4, 3), workbook.celltype(4, 3)].join(":")
+
+      # Cells values in row 5:
+      assert_equal "0.01:percentage", [workbook.cell(5, 1), workbook.celltype(5, 1)].join(":")
+      assert_equal "0.01:percentage", [workbook.cell(5, 2), workbook.celltype(5, 2)].join(":")
+      assert_equal "0.01:percentage", [workbook.cell(5, 3), workbook.celltype(5, 3)].join(":")
+    end
+  end
+
+  def test_formula_openoffice
+    with_each_spreadsheet(name: "formula", format: :openoffice) do |workbook|
+      assert_equal 1, workbook.cell("A", 1)
+      assert_equal 2, workbook.cell("A", 2)
+      assert_equal 3, workbook.cell("A", 3)
+      assert_equal 4, workbook.cell("A", 4)
+      assert_equal 5, workbook.cell("A", 5)
+      assert_equal 6, workbook.cell("A", 6)
+      assert_equal 21, workbook.cell("A", 7)
+      assert_equal :formula, workbook.celltype("A", 7)
+      assert_equal "=[Sheet2.A1]", workbook.formula("C", 7)
+      assert_nil workbook.formula("A", 6)
+      expected_formulas = [
+        [7, 1, "=SUM([.A1:.A6])"],
+        [7, 2, "=SUM([.$A$1:.B6])"],
+        [7, 3, "=[Sheet2.A1]"],
+        [8, 2, "=SUM([.$A$1:.B7])"],
+      ]
+      assert_equal expected_formulas, workbook.formulas(workbook.sheets.first)
+
+      # setting a cell
+      workbook.set("A", 15, 41)
+      assert_equal 41, workbook.cell("A", 15)
+      workbook.set("A", 16, "41")
+      assert_equal "41", workbook.cell("A", 16)
+      workbook.set("A", 17, 42.5)
+      assert_equal 42.5, workbook.cell("A", 17)
+    end
+  end
+
+  def test_bug_ric
+    with_each_spreadsheet(name: "ric", format: :openoffice) do |workbook|
+      assert workbook.empty?("A", 1)
+      assert workbook.empty?("B", 1)
+      assert workbook.empty?("C", 1)
+      assert workbook.empty?("D", 1)
+      expected = 1
+      letter = "e"
+      while letter <= "u"
+        assert_equal expected, workbook.cell(letter, 1)
+        letter.succ!
+        expected += 1
+      end
+      assert_equal "J", workbook.cell("v", 1)
+      assert_equal "P", workbook.cell("w", 1)
+      assert_equal "B", workbook.cell("x", 1)
+      assert_equal "All", workbook.cell("y", 1)
+      assert_equal 0, workbook.cell("a", 2)
+      assert workbook.empty?("b", 2)
+      assert workbook.empty?("c", 2)
+      assert workbook.empty?("d", 2)
+      assert_equal "B", workbook.cell("e", 2)
+      assert_equal "B", workbook.cell("f", 2)
+      assert_equal "B", workbook.cell("g", 2)
+      assert_equal "B", workbook.cell("h", 2)
+      assert_equal "B", workbook.cell("i", 2)
+      assert_equal "B", workbook.cell("j", 2)
+      assert_equal "B", workbook.cell("k", 2)
+      assert_equal "B", workbook.cell("l", 2)
+      assert_equal "B", workbook.cell("m", 2)
+      assert_equal "B", workbook.cell("n", 2)
+      assert_equal "B", workbook.cell("o", 2)
+      assert_equal "B", workbook.cell("p", 2)
+      assert_equal "B", workbook.cell("q", 2)
+      assert_equal "B", workbook.cell("r", 2)
+      assert_equal "B", workbook.cell("s", 2)
+      assert workbook.empty?("t", 2)
+      assert workbook.empty?("u", 2)
+      assert_equal 0, workbook.cell("v", 2)
+      assert_equal 0, workbook.cell("w", 2)
+      assert_equal 15, workbook.cell("x", 2)
+      assert_equal 15, workbook.cell("y", 2)
+    end
+  end
+
+  def test_mehrteilig
+    with_each_spreadsheet(name: "Bibelbund1", format: :openoffice) do |workbook|
+      assert_equal "Tagebuch des Sekret\303\244rs.    Letzte Tagung 15./16.11.75 Schweiz", workbook.cell(45, "A")
+    end
+  end
+
+  def test_cell_openoffice_html_escape
+    with_each_spreadsheet(name: "html-escape", format: :openoffice) do |workbook|
+      assert_equal "'", workbook.cell(1, 1)
+      assert_equal "&", workbook.cell(2, 1)
+      assert_equal ">", workbook.cell(3, 1)
+      assert_equal "<", workbook.cell(4, 1)
+      assert_equal "`", workbook.cell(5, 1)
+      # test_openoffice_zipped will catch issues with &quot;
     end
   end
 

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -10,20 +10,14 @@ require 'test_helper'
 require 'stringio'
 
 class TestRoo < Minitest::Test
-  LONG_RUN = ENV["LONG_RUN"] ? true : false
+  include TestSheets
+  include TestAccesingFiles
+  include TestFormulas
+  include TestComments
+  include TestLabels
+  include TestStyles
 
-  def test_sheets
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      assert_equal ["Tabelle1","Name of Sheet 2","Sheet3","Sheet4","Sheet5"], oo.sheets
-      assert_raises(RangeError) { oo.default_sheet = "no_sheet" }
-      assert_raises(TypeError)  { oo.default_sheet = [1,2,3] }
-      oo.sheets.each { |sh|
-        oo.default_sheet = sh
-        assert_equal sh, oo.default_sheet
-      }
-    end
-  end
-
+  # Cell related tests
   def test_cells
     with_each_spreadsheet(:name=>'numbers1') do |oo|
       # warum ist Auswaehlen erstes sheet hier nicht
@@ -62,12 +56,6 @@ class TestRoo < Minitest::Test
     end
   end
 
-  def test_celltype
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      assert_equal :string, oo.celltype(2,6)
-    end
-  end
-
   def test_cell_address
     with_each_spreadsheet(:name=>'numbers1') do |oo|
       assert_equal "tata", oo.cell(6,1)
@@ -87,46 +75,6 @@ class TestRoo < Minitest::Test
     end
   end
 
-  def test_office_version
-    with_each_spreadsheet(:name=>'numbers1', :format=>:openoffice) do |oo|
-      assert_equal "1.0", oo.officeversion
-    end
-  end
-
-  def test_sheetname
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      oo.default_sheet = "Name of Sheet 2"
-      assert_equal 'I am sheet 2', oo.cell('C',5)
-      assert_raises(RangeError) { oo.default_sheet = "non existing sheet name" }
-      assert_raises(RangeError) { oo.default_sheet = "non existing sheet name" }
-      assert_raises(RangeError) { oo.cell('C',5,"non existing sheet name")}
-      assert_raises(RangeError) { oo.celltype('C',5,"non existing sheet name")}
-      assert_raises(RangeError) { oo.empty?('C',5,"non existing sheet name")}
-      assert_raises(RangeError) { oo.formula?('C',5,"non existing sheet name")}
-      assert_raises(RangeError) { oo.formula('C',5,"non existing sheet name")}
-      assert_raises(RangeError) { oo.set('C',5,42,"non existing sheet name")}
-      assert_raises(RangeError) { oo.formulas("non existing sheet name")}
-      assert_raises(RangeError) { oo.to_yaml({},1,1,1,1,"non existing sheet name")}
-    end
-  end
-
-  def test_argument_error
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      oo.default_sheet = "Tabelle1"
-    end
-  end
-
-  def test_bug_contiguous_cells
-    with_each_spreadsheet(:name=>'numbers1', :format=>:openoffice) do |oo|
-      oo.default_sheet = "Sheet4"
-      assert_equal Date.new(2007,06,16), oo.cell('a',1)
-      assert_equal 10, oo.cell('b',1)
-      assert_equal 10, oo.cell('c',1)
-      assert_equal 10, oo.cell('d',1)
-      assert_equal 10, oo.cell('e',1)
-    end
-  end
-
   def test_bug_italo_ve
     with_each_spreadsheet(:name=>'numbers1') do |oo|
       oo.default_sheet = "Sheet5"
@@ -138,83 +86,15 @@ class TestRoo < Minitest::Test
     end
   end
 
-  def test_italo_table
-    with_each_spreadsheet(:name=>'simple_spreadsheet_from_italo', :format=>:openoffice) do |oo|
-      assert_equal  '1', oo.cell('A',1)
-      assert_equal  '1', oo.cell('B',1)
-      assert_equal  '1', oo.cell('C',1)
-      assert_equal  1, oo.cell('A',2).to_i
-      assert_equal  2, oo.cell('B',2).to_i
-      assert_equal  1, oo.cell('C',2).to_i
-      assert_equal  1, oo.cell('A',3)
-      assert_equal  3, oo.cell('B',3)
-      assert_equal  1, oo.cell('C',3)
-      assert_equal  'A', oo.cell('A',4)
-      assert_equal  'A', oo.cell('B',4)
-      assert_equal  'A', oo.cell('C',4)
-      assert_equal  0.01, oo.cell('A',5)
-      assert_equal  0.01, oo.cell('B',5)
-      assert_equal  0.01, oo.cell('C',5)
-      assert_equal 0.03, oo.cell('a',5)+oo.cell('b',5)+oo.cell('c',5)
-
-      # Cells values in row 1:
-      assert_equal "1:string", oo.cell(1, 1)+":"+oo.celltype(1, 1).to_s
-      assert_equal "1:string",oo.cell(1, 2)+":"+oo.celltype(1, 2).to_s
-      assert_equal "1:string",oo.cell(1, 3)+":"+oo.celltype(1, 3).to_s
-
-      # Cells values in row 2:
-      assert_equal "1:string",oo.cell(2, 1)+":"+oo.celltype(2, 1).to_s
-      assert_equal "2:string",oo.cell(2, 2)+":"+oo.celltype(2, 2).to_s
-      assert_equal "1:string",oo.cell(2, 3)+":"+oo.celltype(2, 3).to_s
-
-      # Cells values in row 3:
-      assert_equal "1:float",oo.cell(3, 1).to_s+":"+oo.celltype(3, 1).to_s
-      assert_equal "3:float",oo.cell(3, 2).to_s+":"+oo.celltype(3, 2).to_s
-      assert_equal "1:float",oo.cell(3, 3).to_s+":"+oo.celltype(3, 3).to_s
-
-      # Cells values in row 4:
-      assert_equal "A:string",oo.cell(4, 1)+":"+oo.celltype(4, 1).to_s
-      assert_equal "A:string",oo.cell(4, 2)+":"+oo.celltype(4, 2).to_s
-      assert_equal "A:string",oo.cell(4, 3)+":"+oo.celltype(4, 3).to_s
-
-      # Cells values in row 5:
-      if oo.class == Roo::OpenOffice
-        assert_equal "0.01:percentage",oo.cell(5, 1).to_s+":"+oo.celltype(5, 1).to_s
-        assert_equal "0.01:percentage",oo.cell(5, 2).to_s+":"+oo.celltype(5, 2).to_s
-        assert_equal "0.01:percentage",oo.cell(5, 3).to_s+":"+oo.celltype(5, 3).to_s
-      else
-        assert_equal "0.01:float",oo.cell(5, 1).to_s+":"+oo.celltype(5, 1).to_s
-        assert_equal "0.01:float",oo.cell(5, 2).to_s+":"+oo.celltype(5, 2).to_s
-        assert_equal "0.01:float",oo.cell(5, 3).to_s+":"+oo.celltype(5, 3).to_s
-      end
+  def test_celltype
+    with_each_spreadsheet(:name=>'numbers1') do |oo|
+      assert_equal :string, oo.celltype(2,6)
     end
   end
 
-  def test_formula_openoffice
-    with_each_spreadsheet(:name=>'formula', :format=>:openoffice) do |oo|
-      assert_equal 1, oo.cell('A',1)
-      assert_equal 2, oo.cell('A',2)
-      assert_equal 3, oo.cell('A',3)
-      assert_equal 4, oo.cell('A',4)
-      assert_equal 5, oo.cell('A',5)
-      assert_equal 6, oo.cell('A',6)
-      assert_equal 21, oo.cell('A',7)
-      assert_equal :formula, oo.celltype('A',7)
-      assert_equal "=[Sheet2.A1]", oo.formula('C',7)
-      assert_nil oo.formula('A',6)
-      assert_equal [[7, 1, "=SUM([.A1:.A6])"],
-        [7, 2, "=SUM([.$A$1:.B6])"],
-        [7, 3, "=[Sheet2.A1]"],
-        [8, 2, "=SUM([.$A$1:.B7])"],
-      ], oo.formulas(oo.sheets.first)
-
-      # setting a cell
-      oo.set('A',15, 41)
-      assert_equal 41, oo.cell('A',15)
-      oo.set('A',16, "41")
-      assert_equal "41", oo.cell('A',16)
-      oo.set('A',17, 42.5)
-      assert_equal 42.5, oo.cell('A',17)
+  def test_argument_error
+    with_each_spreadsheet(:name=>'numbers1') do |oo|
+      oo.default_sheet = "Tabelle1"
     end
   end
 
@@ -249,57 +129,6 @@ class TestRoo < Minitest::Test
       assert_equal 42, oo.cell('B',4)
       assert_equal 43, oo.cell('C',4)
       assert_equal 44, oo.cell('D',4)
-    end
-  end
-
-  def test_bug_ric
-    with_each_spreadsheet(:name=>'ric', :format=>:openoffice) do |oo|
-      assert oo.empty?('A',1)
-      assert oo.empty?('B',1)
-      assert oo.empty?('C',1)
-      assert oo.empty?('D',1)
-      expected = 1
-      letter = 'e'
-      while letter <= 'u'
-        assert_equal expected, oo.cell(letter,1)
-        letter.succ!
-        expected += 1
-      end
-      assert_equal 'J', oo.cell('v',1)
-      assert_equal 'P', oo.cell('w',1)
-      assert_equal 'B', oo.cell('x',1)
-      assert_equal 'All', oo.cell('y',1)
-      assert_equal 0, oo.cell('a',2)
-      assert oo.empty?('b',2)
-      assert oo.empty?('c',2)
-      assert oo.empty?('d',2)
-      assert_equal 'B', oo.cell('e',2)
-      assert_equal 'B', oo.cell('f',2)
-      assert_equal 'B', oo.cell('g',2)
-      assert_equal 'B', oo.cell('h',2)
-      assert_equal 'B', oo.cell('i',2)
-      assert_equal 'B', oo.cell('j',2)
-      assert_equal 'B', oo.cell('k',2)
-      assert_equal 'B', oo.cell('l',2)
-      assert_equal 'B', oo.cell('m',2)
-      assert_equal 'B', oo.cell('n',2)
-      assert_equal 'B', oo.cell('o',2)
-      assert_equal 'B', oo.cell('p',2)
-      assert_equal 'B', oo.cell('q',2)
-      assert_equal 'B', oo.cell('r',2)
-      assert_equal 'B', oo.cell('s',2)
-      assert oo.empty?('t',2)
-      assert oo.empty?('u',2)
-      assert_equal 0  , oo.cell('v',2)
-      assert_equal 0  , oo.cell('w',2)
-      assert_equal 15 , oo.cell('x',2)
-      assert_equal 15 , oo.cell('y',2)
-    end
-  end
-
-  def test_mehrteilig
-    with_each_spreadsheet(:name=>'Bibelbund1', :format=>:openoffice) do |oo|
-      assert_equal "Tagebuch des Sekret\303\244rs.    Letzte Tagung 15./16.11.75 Schweiz", oo.cell(45,'A')
     end
   end
 
@@ -382,271 +211,7 @@ class TestRoo < Minitest::Test
     end
   end
 
-  def test_find_by_row_huge_document
-    if LONG_RUN
-      with_each_spreadsheet(:name=>'Bibelbund', :format=>[:openoffice, :excelx]) do |oo|
-        oo.default_sheet = oo.sheets.first
-        rec = oo.find 20
-        assert rec
-        # assert_equal "Brief aus dem Sekretariat", rec[0]
-        #p rec
-        assert_equal "Brief aus dem Sekretariat", rec[0]['TITEL']
-        rec = oo.find 22
-        assert rec
-        # assert_equal "Brief aus dem Skretariat. Tagung in Amberg/Opf.",rec[0]
-        assert_equal "Brief aus dem Skretariat. Tagung in Amberg/Opf.",rec[0]['TITEL']
-      end
-    end
-  end
-
-  def test_find_by_row
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      oo.header_line = nil
-      rec = oo.find 16
-      assert rec
-      assert_nil oo.header_line
-      # keine Headerlines in diesem Beispiel definiert
-      assert_equal "einundvierzig", rec[0]
-      #assert_equal false, rec
-      rec = oo.find 15
-      assert rec
-      assert_equal 41,rec[0]
-    end
-  end
-
-  def test_find_by_row_if_header_line_is_not_nil
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      oo.header_line = 2
-      refute_nil oo.header_line
-      rec = oo.find 1
-      assert rec
-      assert_equal 5, rec[0]
-      assert_equal 6, rec[1]
-      rec = oo.find 15
-      assert rec
-      assert_equal "einundvierzig", rec[0]
-    end
-  end
-
-  def test_find_by_conditions
-    if LONG_RUN
-      with_each_spreadsheet(:name=>'Bibelbund', :format=>[:openoffice,
-          :excelx]) do |oo|
-        #-----------------------------------------------------------------
-        zeilen = oo.find(:all, :conditions => {
-            'TITEL' => 'Brief aus dem Sekretariat'
-          }
-        )
-        assert_equal 2, zeilen.size
-        assert_equal [{"VERFASSER"=>"Almassy, Annelene von",
-            "INTERNET"=>nil,
-            "SEITE"=>316.0,
-            "KENNUNG"=>"Aus dem Bibelbund",
-            "OBJEKT"=>"Bibel+Gem",
-            "PC"=>"#C:\\Bibelbund\\reprint\\BuG1982-3.pdf#",
-            "NUMMER"=>"1982-3",
-            "TITEL"=>"Brief aus dem Sekretariat"},
-          {"VERFASSER"=>"Almassy, Annelene von",
-            "INTERNET"=>nil,
-            "SEITE"=>222.0,
-            "KENNUNG"=>"Aus dem Bibelbund",
-            "OBJEKT"=>"Bibel+Gem",
-            "PC"=>"#C:\\Bibelbund\\reprint\\BuG1983-2.pdf#",
-            "NUMMER"=>"1983-2",
-            "TITEL"=>"Brief aus dem Sekretariat"}] , zeilen
-
-        #----------------------------------------------------------
-        zeilen = oo.find(:all,
-          :conditions => { 'VERFASSER' => 'Almassy, Annelene von' }
-        )
-        assert_equal 13, zeilen.size
-        #----------------------------------------------------------
-        zeilen = oo.find(:all, :conditions => {
-            'TITEL' => 'Brief aus dem Sekretariat',
-            'VERFASSER' => 'Almassy, Annelene von',
-          }
-        )
-        assert_equal 2, zeilen.size
-        assert_equal [{"VERFASSER"=>"Almassy, Annelene von",
-            "INTERNET"=>nil,
-            "SEITE"=>316.0,
-            "KENNUNG"=>"Aus dem Bibelbund",
-            "OBJEKT"=>"Bibel+Gem",
-            "PC"=>"#C:\\Bibelbund\\reprint\\BuG1982-3.pdf#",
-            "NUMMER"=>"1982-3",
-            "TITEL"=>"Brief aus dem Sekretariat"},
-          {"VERFASSER"=>"Almassy, Annelene von",
-            "INTERNET"=>nil,
-            "SEITE"=>222.0,
-            "KENNUNG"=>"Aus dem Bibelbund",
-            "OBJEKT"=>"Bibel+Gem",
-            "PC"=>"#C:\\Bibelbund\\reprint\\BuG1983-2.pdf#",
-            "NUMMER"=>"1983-2",
-            "TITEL"=>"Brief aus dem Sekretariat"}] , zeilen
-
-        # Result as an array
-        zeilen = oo.find(:all,
-          :conditions => {
-            'TITEL' => 'Brief aus dem Sekretariat',
-            'VERFASSER' => 'Almassy, Annelene von',
-          }, :array => true)
-        assert_equal 2, zeilen.size
-        assert_equal [
-          [
-            "Brief aus dem Sekretariat",
-            "Almassy, Annelene von",
-            "Bibel+Gem",
-            "1982-3",
-            316.0,
-            nil,
-            "#C:\\Bibelbund\\reprint\\BuG1982-3.pdf#",
-            "Aus dem Bibelbund",
-          ],
-          [
-            "Brief aus dem Sekretariat",
-            "Almassy, Annelene von",
-            "Bibel+Gem",
-            "1983-2",
-            222.0,
-            nil,
-            "#C:\\Bibelbund\\reprint\\BuG1983-2.pdf#",
-            "Aus dem Bibelbund",
-          ]] , zeilen
-      end
-    end
-  end
-
-  #TODO: temporaerer Test
-  def test_seiten_als_date
-    if LONG_RUN
-      with_each_spreadsheet(:name=>'Bibelbund', :format=>:excelx) do |oo|
-        assert_equal 'Bericht aus dem Sekretariat', oo.cell(13,1)
-        assert_equal '1981-4', oo.cell(13,'D')
-        assert_equal String, oo.excelx_type(13,'E')[1].class
-        assert_equal [:numeric_or_formula,"General"], oo.excelx_type(13,'E')
-        assert_equal '428', oo.excelx_value(13,'E')
-        assert_equal 428.0, oo.cell(13,'E')
-      end
-    end
-  end
-
-  def test_column
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      expected = [1.0,5.0,nil,10.0,Date.new(1961,11,21),'tata',nil,nil,nil,nil,'thisisa11',41.0,nil,nil,41.0,'einundvierzig',nil,Date.new(2007,5,31)]
-      assert_equal expected, oo.column(1)
-      assert_equal expected, oo.column('a')
-    end
-  end
-
-  def test_column_huge_document
-    if LONG_RUN
-      with_each_spreadsheet(:name=>'Bibelbund', :format=>[:openoffice,
-          :excelx]) do |oo|
-        oo.default_sheet = oo.sheets.first
-        assert_equal 3735, oo.column('a').size
-        #assert_equal 499, oo.column('a').size
-      end
-    end
-  end
-
-  def test_simple_spreadsheet_find_by_condition
-    with_each_spreadsheet(:name=>'simple_spreadsheet') do |oo|
-      oo.header_line = 3
-      # oo.date_format = '%m/%d/%Y' if oo.class == Google
-      erg = oo.find(:all, :conditions => {'Comment' => 'Task 1'})
-      assert_equal Date.new(2007,05,07), erg[1]['Date']
-      assert_equal 10.75       , erg[1]['Start time']
-      assert_equal 12.50       , erg[1]['End time']
-      assert_equal 0           , erg[1]['Pause']
-      assert_equal 1.75        , erg[1]['Sum']
-      assert_equal "Task 1"    , erg[1]['Comment']
-    end
-  end
-
-  def get_extension(oo)
-    case oo
-    when Roo::OpenOffice
-      ".ods"
-    when Roo::Excelx
-      ".xlsx"
-    end
-  end
-
-  def test_info
-    expected_templ = "File: numbers1%s\n"+
-      "Number of sheets: 5\n"+
-      "Sheets: Tabelle1, Name of Sheet 2, Sheet3, Sheet4, Sheet5\n"+
-      "Sheet 1:\n"+
-      "  First row: 1\n"+
-      "  Last row: 18\n"+
-      "  First column: A\n"+
-      "  Last column: G\n"+
-      "Sheet 2:\n"+
-      "  First row: 5\n"+
-      "  Last row: 14\n"+
-      "  First column: B\n"+
-      "  Last column: E\n"+
-      "Sheet 3:\n"+
-      "  First row: 1\n"+
-      "  Last row: 1\n"+
-      "  First column: A\n"+
-      "  Last column: BA\n"+
-      "Sheet 4:\n"+
-      "  First row: 1\n"+
-      "  Last row: 1\n"+
-      "  First column: A\n"+
-      "  Last column: E\n"+
-      "Sheet 5:\n"+
-      "  First row: 1\n"+
-      "  Last row: 6\n"+
-      "  First column: A\n"+
-      "  Last column: E"
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      ext = get_extension(oo)
-      expected = sprintf(expected_templ,ext)
-      begin
-        if oo.class == Google
-          assert_equal expected.gsub(/numbers1/,key_of("numbers1")), oo.info
-        else
-          assert_equal expected, oo.info
-        end
-      rescue NameError
-        #
-      end
-    end
-  end
-
-  def test_info_doesnt_set_default_sheet
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      oo.default_sheet = 'Sheet3'
-      oo.info
-      assert_equal 'Sheet3', oo.default_sheet
-    end
-  end
-
-  def test_bug_bbu
-    with_each_spreadsheet(:name=>'bbu', :format=>[:openoffice, :excelx]) do |oo|
-        assert_equal "File: bbu#{get_extension(oo)}
-Number of sheets: 3
-Sheets: 2007_12, Tabelle2, Tabelle3
-Sheet 1:
-  First row: 1
-  Last row: 4
-  First column: A
-  Last column: F
-Sheet 2:
-  - empty -
-Sheet 3:
-  - empty -", oo.info
-
-      oo.default_sheet = oo.sheets[1] # empty sheet
-      assert_nil oo.first_row
-      assert_nil oo.last_row
-      assert_nil oo.first_column
-      assert_nil oo.last_column
-    end
-  end
-
+  # Tests for Specific Cell types (time, etc)
 
   def test_bug_time_nil
     with_each_spreadsheet(:name=>'time-test') do |oo|
@@ -656,54 +221,6 @@ Sheet 3:
       assert_equal :time, oo.celltype('C',1)
       assert_equal 23*3600, oo.cell('D',1) # 23:00    (secs since midnight)
       assert_equal :time, oo.celltype('D',1)
-    end
-  end
-
-  def test_bug_simple_spreadsheet_time_bug
-    # really a bug? are cells really of type time?
-    # No! :float must be the correct type
-    with_each_spreadsheet(:name=>'simple_spreadsheet', :format=>:excelx) do |oo|
-      # puts oo.cell('B',5).to_s
-      # assert_equal :time, oo.celltype('B',5)
-      assert_equal :float, oo.celltype('B',5)
-      assert_equal 10.75, oo.cell('B',5)
-      assert_equal 12.50, oo.cell('C',5)
-      assert_equal 0, oo.cell('D',5)
-      assert_equal 1.75, oo.cell('E',5)
-      assert_equal 'Task 1', oo.cell('F',5)
-      assert_equal Date.new(2007,5,7), oo.cell('A',5)
-    end
-  end
-
-  def test_simple2_excelx
-    with_each_spreadsheet(:name=>'simple_spreadsheet', :format=>:excelx) do |oo|
-      assert_equal [:numeric_or_formula, "yyyy\\-mm\\-dd"], oo.excelx_type('A',4)
-      assert_equal [:numeric_or_formula, "#,##0.00"], oo.excelx_type('B',4)
-      assert_equal [:numeric_or_formula, "#,##0.00"], oo.excelx_type('c',4)
-      assert_equal [:numeric_or_formula, "General"], oo.excelx_type('d',4)
-      assert_equal [:numeric_or_formula, "General"], oo.excelx_type('e',4)
-      assert_equal :string, oo.excelx_type('f',4)
-
-      assert_equal "39209", oo.excelx_value('a',4)
-      assert_equal "yyyy\\-mm\\-dd", oo.excelx_format('a',4)
-      assert_equal "9.25", oo.excelx_value('b',4)
-      assert_equal "10.25", oo.excelx_value('c',4)
-      assert_equal "0", oo.excelx_value('d',4)
-      #... Sum-Spalte
-      # assert_equal "Task 1", oo.excelx_value('f',4)
-      assert_equal "Task 1", oo.cell('f',4)
-      assert_equal Date.new(2007,05,07), oo.cell('a',4)
-      assert_equal "9.25", oo.excelx_value('b',4)
-      assert_equal "#,##0.00", oo.excelx_format('b',4)
-      assert_equal 9.25, oo.cell('b',4)
-      assert_equal :float, oo.celltype('b',4)
-      assert_equal :float, oo.celltype('d',4)
-      assert_equal 0, oo.cell('d',4)
-      assert_equal :formula, oo.celltype('e',4)
-      assert_equal 1, oo.cell('e',4)
-      assert_equal 'C4-B4-D4', oo.formula('e',4)
-      assert_equal :string, oo.celltype('f',4)
-      assert_equal "Task 1", oo.cell('f',4)
     end
   end
 
@@ -739,17 +256,6 @@ Sheet 3:
     end
   end
 
-  def test_cell_openoffice_html_escape
-    with_each_spreadsheet(:name=>'html-escape', :format=>:openoffice) do |oo|
-      assert_equal "'", oo.cell(1,1)
-      assert_equal "&", oo.cell(2,1)
-      assert_equal ">", oo.cell(3,1)
-      assert_equal "<", oo.cell(4,1)
-      assert_equal "`", oo.cell(5,1)
-      # test_openoffice_zipped will catch issues with &quot;
-    end
-  end
-
   def test_cell_boolean
     with_each_spreadsheet(:name=>'boolean', :format=>[:openoffice, :excelx]) do |oo|
       if oo.class == Roo::Excelx
@@ -776,72 +282,9 @@ Sheet 3:
     end
   end
 
-  def test_cell_styles
-    # styles only valid in excel spreadsheets?
-    # TODO: what todo with other spreadsheet types
-    with_each_spreadsheet(:name=>'style', :format=>[# :openoffice,
-        :excelx
-      ]) do |oo|
-      # bold
-      assert_equal true,  oo.font(1,1).bold?
-      assert_equal false, oo.font(1,1).italic?
-      assert_equal false, oo.font(1,1).underline?
-
-      # italic
-      assert_equal false, oo.font(2,1).bold?
-      assert_equal true,  oo.font(2,1).italic?
-      assert_equal false, oo.font(2,1).underline?
-
-      # normal
-      assert_equal false, oo.font(3,1).bold?
-      assert_equal false, oo.font(3,1).italic?
-      assert_equal false, oo.font(3,1).underline?
-
-      # underline
-      assert_equal false, oo.font(4,1).bold?
-      assert_equal false, oo.font(4,1).italic?
-      assert_equal true,  oo.font(4,1).underline?
-
-      # bold italic
-      assert_equal true,  oo.font(5,1).bold?
-      assert_equal true,  oo.font(5,1).italic?
-      assert_equal false, oo.font(5,1).underline?
-
-      # bold underline
-      assert_equal true,  oo.font(6,1).bold?
-      assert_equal false, oo.font(6,1).italic?
-      assert_equal true,  oo.font(6,1).underline?
-
-      # italic underline
-      assert_equal false, oo.font(7,1).bold?
-      assert_equal true,  oo.font(7,1).italic?
-      assert_equal true,  oo.font(7,1).underline?
-
-      # bolded row
-      assert_equal true, oo.font(8,1).bold?
-      assert_equal false,  oo.font(8,1).italic?
-      assert_equal false,  oo.font(8,1).underline?
-
-      # bolded col
-      assert_equal true, oo.font(9,2).bold?
-      assert_equal false,  oo.font(9,2).italic?
-      assert_equal false,  oo.font(9,2).underline?
-
-      # bolded row, italic col
-      assert_equal true, oo.font(10,3).bold?
-      assert_equal true,  oo.font(10,3).italic?
-      assert_equal false,  oo.font(10,3).underline?
-
-      # normal
-      assert_equal false, oo.font(11,4).bold?
-      assert_equal false,  oo.font(11,4).italic?
-      assert_equal false,  oo.font(11,4).underline?
-    end
-  end
-
-  # Need to extend to other formats
   def test_row_whitespace
     # auf dieses Dokument habe ich keinen Zugriff TODO:
+    # TODO: No access to document whitespace?
     with_each_spreadsheet(:name=>'whitespace') do |oo|
       oo.default_sheet = "Sheet1"
       assert_equal [nil, nil, nil, nil, nil, nil], oo.row(1)
@@ -877,26 +320,6 @@ Sheet 3:
     end
   end
 
-  def test_excelx_links
-    with_each_spreadsheet(:name=>'link', :format=>:excelx) do |oo|
-      assert_equal 'Google', oo.cell(1,1)
-      assert_equal 'http://www.google.com', oo.cell(1,1).href
-    end
-  end
-
-  # Excel has two base date formats one from 1900 and the other from 1904.
-  # see #test_base_dates_in_excel
-  def test_base_dates_in_excelx
-    with_each_spreadsheet(:name=>'1900_base', :format=>:excelx) do |oo|
-      assert_equal Date.new(2009,06,15), oo.cell(1,1)
-      assert_equal :date, oo.celltype(1,1)
-    end
-    with_each_spreadsheet(:name=>'1904_base', :format=>:excelx) do |oo|
-      assert_equal Date.new(2009,06,15), oo.cell(1,1)
-      assert_equal :date, oo.celltype(1,1)
-    end
-  end
-
   def test_cell_methods
     with_each_spreadsheet(:name=>'numbers1') do |oo|
       assert_equal 10, oo.a4 # cell(4,'A')
@@ -917,251 +340,23 @@ Sheet 3:
   # compare large spreadsheets
   def test_compare_large_spreadsheets
     # problematisch, weil Formeln in Excel nicht unterstützt werden
-    if LONG_RUN
-      qq = Roo::OpenOffice.new(File.join('test',"Bibelbund.ods"))
-      with_each_spreadsheet(:name=>'Bibelbund') do |oo|
-        # p "comparing Bibelbund.ods with #{oo.class}"
-        oo.sheets.each do |sh|
-          oo.first_row.upto(oo.last_row) do |row|
-            oo.first_column.upto(oo.last_column) do |col|
-              c1 = qq.cell(row,col,sh)
-              c1.force_encoding("UTF-8") if c1.class == String
-              c2 = oo.cell(row,col,sh)
-              c2.force_encoding("UTF-8") if c2.class == String
-              assert_equal c1, c2, "diff in #{sh}/#{row}/#{col}}"
-              assert_equal qq.celltype(row,col,sh), oo.celltype(row,col,sh)
-              assert_equal qq.formula?(row,col,sh), oo.formula?(row,col,sh) if oo.class != Roo::Excel
-            end
+    skip_long_test
+    qq = Roo::OpenOffice.new(File.join('test',"Bibelbund.ods"))
+    with_each_spreadsheet(:name=>'Bibelbund') do |oo|
+      # p "comparing Bibelbund.ods with #{oo.class}"
+      oo.sheets.each do |sh|
+        oo.first_row.upto(oo.last_row) do |row|
+          oo.first_column.upto(oo.last_column) do |col|
+            c1 = qq.cell(row,col,sh)
+            c1.force_encoding("UTF-8") if c1.class == String
+            c2 = oo.cell(row,col,sh)
+            c2.force_encoding("UTF-8") if c2.class == String
+            assert_equal c1, c2, "diff in #{sh}/#{row}/#{col}}"
+            assert_equal qq.celltype(row,col,sh), oo.celltype(row,col,sh)
+            assert_equal qq.formula?(row,col,sh), oo.formula?(row,col,sh) if oo.class != Roo::Excel
           end
         end
       end
-    end # LONG_RUN
-  end
-
-  def test_label
-    with_each_spreadsheet(:name=>'named_cells', :format=>[:openoffice,:excelx,:libreoffice]) do |oo|
-      # oo.default_sheet = oo.sheets.first
-      begin
-        row,col = oo.label('anton')
-      rescue ArgumentError
-        puts "labels error at #{oo.class}"
-        raise
-      end
-      assert_equal 5, row, "error with label in class #{oo.class}"
-      assert_equal 3, col, "error with label in class #{oo.class}"
-
-      row,col = oo.label('anton')
-      assert_equal 'Anton', oo.cell(row,col), "error with label in class #{oo.class}"
-
-      row,col = oo.label('berta')
-      assert_equal 'Bertha', oo.cell(row,col), "error with label in class #{oo.class}"
-
-      row,col = oo.label('caesar')
-      assert_equal 'Cäsar', oo.cell(row,col),"error with label in class #{oo.class}"
-
-      row,col = oo.label('never')
-      assert_nil row
-      assert_nil col
-
-      row,col,sheet = oo.label('anton')
-      assert_equal 5, row
-      assert_equal 3, col
-      assert_equal "Sheet1", sheet
     end
   end
-
-  def test_method_missing_anton
-    with_each_spreadsheet(:name=>'named_cells', :format=>[:openoffice,:excelx,:libreoffice]) do |oo|
-      # oo.default_sheet = oo.sheets.first
-      assert_equal "Anton", oo.anton
-      assert_raises(NoMethodError) {
-        oo.never
-      }
-    end
-  end
-
-  def test_labels
-    with_each_spreadsheet(:name=>'named_cells', :format=>[:openoffice,:excelx,:libreoffice]) do |oo|
-      # oo.default_sheet = oo.sheets.first
-      assert_equal [
-        ['anton',[5,3,'Sheet1']],
-        ['berta',[4,2,'Sheet1']],
-        ['caesar',[7,2,'Sheet1']],
-      ], oo.labels, "error with labels array in class #{oo.class}"
-    end
-  end
-
-   def test_labeled_cells
-     with_each_spreadsheet(:name=>'named_cells', :format=>[:openoffice,:excelx,:libreoffice]) do |oo|
-       oo.default_sheet = oo.sheets.first
-       begin
-         row,col = oo.label('anton')
-       rescue ArgumentError
-         puts "labels error at #{oo.class}"
-         raise
-       end
-       assert_equal 5, row
-       assert_equal 3, col
-
-       row,col = oo.label('anton')
-       assert_equal 'Anton', oo.cell(row,col)
-
-       row,col = oo.label('berta')
-       assert_equal 'Bertha', oo.cell(row,col)
-
-       row,col = oo.label('caesar')
-       assert_equal 'Cäsar', oo.cell(row,col)
-
-       row,col = oo.label('never')
-       assert_nil row
-       assert_nil col
-
-       row,col,sheet = oo.label('anton')
-       assert_equal 5, row
-       assert_equal 3, col
-       assert_equal "Sheet1", sheet
-
-       assert_equal "Anton", oo.anton
-       assert_raises(NoMethodError) {
-         row,col = oo.never
-       }
-
-  # Reihenfolge row,col,sheet analog zu #label
-       assert_equal [
-         ['anton',[5,3,'Sheet1']],
-         ['berta',[4,2,'Sheet1']],
-         ['caesar',[7,2,'Sheet1']],
-       ], oo.labels, "error with labels array in class #{oo.class}"
-     end
-   end
-
-  # #formulas of an empty sheet should return an empty array and not result in
-  # an error message
-  # 2011-06-24
-  def test_bug_formulas_empty_sheet
-    with_each_spreadsheet(:name =>'emptysheets',
-      :format=>[:openoffice,:excelx]) do |oo|
-        oo.default_sheet = oo.sheets.first
-        oo.formulas
-      assert_equal([], oo.formulas)
-    end
-  end
-
-  def test_bug_pfand_from_windows_phone_xlsx
-    return if defined? JRUBY_VERSION
-    with_each_spreadsheet(:name=>'Pfand_from_windows_phone', :format=>:excelx) do |oo|
-      oo.default_sheet = oo.sheets.first
-      assert_equal ['Blatt1','Blatt2','Blatt3'], oo.sheets
-      assert_equal 'Summe', oo.cell('b',1)
-
-      assert_equal Date.new(2011,9,14), oo.cell('a',2)
-      assert_equal :date, oo.celltype('a',2)
-      assert_equal Date.new(2011,9,15), oo.cell('a',3)
-      assert_equal :date, oo.celltype('a',3)
-
-      assert_equal 3.81, oo.cell('b',2)
-      assert_equal "SUM(C2:L2)", oo.formula('b',2)
-      assert_equal 0.7, oo.cell('c',2)
-    end # each
-  end
-
-  def test_comment
-    with_each_spreadsheet(:name=>'comments', :format=>[:openoffice,:libreoffice,
-        :excelx]) do |oo|
-      oo.default_sheet = oo.sheets.first
-      assert_equal 'Kommentar fuer B4',oo.comment('b',4)
-      assert_equal 'Kommentar fuer B5',oo.comment('b',5)
-      assert_nil oo.comment('b',99)
-      # no comment at the second page
-      oo.default_sheet = oo.sheets[1]
-      assert_nil oo.comment('b',4)
-    end
-  end
-
-  def test_comments
-    with_each_spreadsheet(:name=>'comments', :format=>[:openoffice,:libreoffice,
-        :excelx]) do |oo|
-      oo.default_sheet = oo.sheets.first
-      assert_equal [
-        [4, 2, "Kommentar fuer B4"],
-        [5, 2, "Kommentar fuer B5"],
-      ], oo.comments(oo.sheets.first), "comments error in class #{oo.class}"
-      # no comments at the second page
-      oo.default_sheet = oo.sheets[1]
-      assert_equal [], oo.comments, "comments error in class #{oo.class}"
-    end
-
-    with_each_spreadsheet(:name=>'comments-google', :format=>[:excelx]) do |oo|
-      oo.default_sheet = oo.sheets.first
-      assert_equal [[1, 1, "this is a comment\n\t-Steven Daniels"]], oo.comments(oo.sheets.first), "comments error in class #{oo.class}"
-    end
-  end
-
-  def common_possible_bug_snowboard_cells(ss)
-    assert_equal "A.", ss.cell(13,'A'), ss.class
-    assert_equal 147, ss.cell(13,'f'), ss.class
-    assert_equal 152, ss.cell(13,'g'), ss.class
-    assert_equal 156, ss.cell(13,'h'), ss.class
-    assert_equal 158, ss.cell(13,'i'), ss.class
-    assert_equal 160, ss.cell(13,'j'), ss.class
-    assert_equal 164, ss.cell(13,'k'), ss.class
-    assert_equal 168, ss.cell(13,'l'), ss.class
-    assert_equal :string, ss.celltype(13,'m'), ss.class
-    assert_equal "159W", ss.cell(13,'m'), ss.class
-    assert_equal "164W", ss.cell(13,'n'), ss.class
-    assert_equal "168W", ss.cell(13,'o'), ss.class
-  end
-
-  def test_bug_numbered_sheet_names
-    with_each_spreadsheet(:name=>'bug-numbered-sheet-names', :format=>:excelx) do |oo|
-      oo.each_with_pagename { }
-    end
-  end
-
-  def test_close
-    with_each_spreadsheet(:name=>'numbers1') do |oo|
-      next unless (tempdir = oo.instance_variable_get('@tmpdir'))
-      oo.close
-      assert !File.exists?(tempdir), "Expected #{tempdir} to be cleaned up, but it still exists"
-    end
-  end
-
-  # NOTE: Ruby 2.4.0 changed the way GC works. The last Roo object created by
-  #       with_each_spreadsheet wasn't getting GC'd until after the process
-  #       ended.
-  #
-  #       That behavior change broke this test. In order to fix it, I forked the
-  #       process and passed the temp directories from the forked process in
-  #       order to check if they were removed properly.
-  def test_finalize
-    skip if defined? JRUBY_VERSION
-
-    read, write = IO.pipe
-    pid = Process.fork do
-      with_each_spreadsheet(name: "numbers1") do |oo|
-        write.puts oo.instance_variable_get("@tmpdir")
-      end
-    end
-
-    Process.wait(pid)
-    write.close
-    tempdirs = read.read.split("\n")
-    read.close
-
-    refute tempdirs.empty?
-    tempdirs.each do |tempdir|
-      refute File.exist?(tempdir), "Expected #{tempdir} to be cleaned up, but it still exists"
-    end
-  end
-
-  def test_cleanup_on_error
-    old_temp_files = Dir.open(Dir.tmpdir).to_a
-    with_each_spreadsheet(:name=>'non_existent_file', :ignore_errors=>true) do |oo|; end
-    assert_equal Dir.open(Dir.tmpdir).to_a, old_temp_files
-  end
-
-  def test_name_with_leading_slash
-    xlsx = Roo::Excelx.new(File.join(TESTDIR,'name_with_leading_slash.xlsx'))
-    assert_equal 1, xlsx.sheets.count
-  end
-end # class
+end


### PR DESCRIPTION
+ Fixed test/formatters/test_xml
+ Refactored tests cases into separate classes and modules

NOTE: Putting these tests into modules in order to share them across different
      test classes, i.e. both TestRooExcelx and TestRooOpenOffice should run
      sheet related tests.

      This will allow me to reuse these test cases when I add new classes for
      Roo's future API.