### PR TITLE
Disable html injection

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -39,6 +39,8 @@ module Roo
       sheet_options = {}
       sheet_options[:expand_merged_ranges] = (options[:expand_merged_ranges] || false)
       sheet_options[:no_hyperlinks] = (options[:no_hyperlinks] || false)
+      shared_options = {}
+      shared_options[:disable_html_wrapper] = (options[:disable_html_wrapper] || false)
 
       unless is_stream?(filename_or_stream)
         file_type_check(filename_or_stream, %w[.xlsx .xlsm], 'an Excel 2007', file_warning, packed)
@@ -52,7 +54,7 @@ module Roo
       @tmpdir = self.class.make_tempdir(self, basename, options[:tmpdir_root])
       ObjectSpace.define_finalizer(self, self.class.finalize(object_id))
 
-      @shared = Shared.new(@tmpdir)
+      @shared = Shared.new(@tmpdir, shared_options)
       @filename = local_filename(filename_or_stream, @tmpdir, packed)
       process_zipfile(@filename || filename_or_stream)
 

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -40,8 +40,8 @@ module Roo
       sheet_options[:expand_merged_ranges] = (options[:expand_merged_ranges] || false)
       sheet_options[:no_hyperlinks] = (options[:no_hyperlinks] || false)
       shared_options = {}
+        
       shared_options[:disable_html_wrapper] = (options[:disable_html_wrapper] || false)
-
       unless is_stream?(filename_or_stream)
         file_type_check(filename_or_stream, %w[.xlsx .xlsm], 'an Excel 2007', file_warning, packed)
         basename = find_basename(filename_or_stream)

--- a/lib/roo/excelx/extractor.rb
+++ b/lib/roo/excelx/extractor.rb
@@ -1,7 +1,7 @@
 module Roo
   class Excelx
     class Extractor
-      def initialize(path, options)
+      def initialize(path, options = {})
         @path = path
         @options = options
       end

--- a/lib/roo/excelx/extractor.rb
+++ b/lib/roo/excelx/extractor.rb
@@ -1,8 +1,9 @@
 module Roo
   class Excelx
     class Extractor
-      def initialize(path)
+      def initialize(path, options)
         @path = path
+        @options = options
       end
 
       private

--- a/lib/roo/excelx/shared.rb
+++ b/lib/roo/excelx/shared.rb
@@ -5,11 +5,12 @@ module Roo
     #          to various inititializers.
     class Shared
       attr_accessor :comments_files, :sheet_files, :rels_files
-      def initialize(dir)
+      def initialize(dir, options = {})
         @dir = dir
         @comments_files = []
         @sheet_files = []
         @rels_files = []
+        @options = options
       end
 
       def styles
@@ -17,7 +18,7 @@ module Roo
       end
 
       def shared_strings
-        @shared_strings ||= SharedStrings.new(File.join(@dir, 'roo_sharedStrings.xml'))
+        @shared_strings ||= SharedStrings.new(File.join(@dir, 'roo_sharedStrings.xml'), @options)
       end
 
       def workbook

--- a/lib/roo/excelx/shared_strings.rb
+++ b/lib/roo/excelx/shared_strings.rb
@@ -26,6 +26,7 @@ module Roo
       # Use to_html or to_a for html returns
       # See what is happening with commit???
       def use_html?(index)
+        return false if options[:disable_html_wrapper]
         to_html[index][/<([biu]|sup|sub)>/]
       end
 

--- a/lib/roo/excelx/shared_strings.rb
+++ b/lib/roo/excelx/shared_strings.rb
@@ -26,7 +26,7 @@ module Roo
       # Use to_html or to_a for html returns
       # See what is happening with commit???
       def use_html?(index)
-        return false if options[:disable_html_wrapper]
+        return false if @options[:disable_html_wrapper]
         to_html[index][/<([biu]|sup|sub)>/]
       end
 

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -519,7 +519,7 @@ describe Roo::Excelx do
         expect(subject.excelx_value(2, 1, "Sheet1")).to eq("This has bold formatting.")
         expect(subject.excelx_value(2, 2, "Sheet1")).to eq("This has italics formatting.")
         expect(subject.excelx_value(2, 3, "Sheet1")).to eq("This has underline format.")
-        expect(subject.excelx_value(2, 4, "Sheet1")).to eq("Superscript. x123<")
+        expect(subject.excelx_value(2, 4, "Sheet1")).to eq("Superscript. x123")
         expect(subject.excelx_value(2, 5, "Sheet1")).to eq("SubScript.  Tj")
   
         expect(subject.excelx_value(3, 1, "Sheet1")).to eq("Bold, italics together.")

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -511,6 +511,39 @@ describe Roo::Excelx do
         expect(subject.excelx_value(7, 1, "Sheet1")).to eq("<html>Does create html tags when formatting is used..\n<ol>\n  <li> <b>Denver Broncos</b> </li>\n  <li> <i>Carolina Panthers </i></li>\n  <li> <u>New England Patriots</u></li>\n  <li>Arizona Panthers</li>\n</ol></html>")
       end
     end
+  end
+
+  describe '_x000D_' do
+    let(:path) { 'test/files/x000D.xlsx' }
+    it 'does not contain _x000D_' do
+      expect(subject.cell(2, 9)).not_to include('_x000D_')
+    end
+  end
+
+  describe 'opening a file with a chart sheet' do
+    let(:path) { 'test/files/chart_sheet.xlsx' }
+    it 'should not raise' do
+      expect{ subject }.to_not raise_error
+    end
+  end
+
+  describe 'opening a file with white space in the styles.xml' do
+    let(:path) { 'test/files/style_nodes_with_white_spaces.xlsx' }
+    subject(:xlsx) do
+      Roo::Spreadsheet.open(path, expand_merged_ranges: true, extension: :xlsx)
+    end
+    it 'should properly recognize formats' do
+      expect(subject.sheet(0).excelx_format(2,1)).to eq 'm/d/yyyy" "h:mm:ss" "AM/PM'
+    end
+  end
+end
+
+describe 'Roo::Excelx with options set' do
+  subject(:xlsx) do
+    Roo::Excelx.new(path, disable_html_wrapper: true)
+  end
+
+  describe '#html_strings' do
     describe "HTML Parsing Disabled" do
       let(:path) { 'test/files/html_strings_formatting.xlsx' }
   
@@ -541,30 +574,6 @@ describe Roo::Excelx do
         expect(subject.excelx_value(6, 1, "Sheet1")).to eq("See that regular html tags do not create html tags.\n<ol>\n  <li> Denver Broncos </li>\n  <li> Carolina Panthers </li>\n  <li> New England Patriots</li>\n  <li>Arizona Panthers</li>\n</ol>")
         expect(subject.excelx_value(7, 1, "Sheet1")).to eq("Does create html tags when formatting is used..\n<ol>\n  <li> Denver Broncos </li>\n  <li> Carolina Panthers </li>\n  <li> New England Patriots</li>\n  <li>Arizona Panthers</li>\n</ol>")
       end
-    end
-  end
-
-  describe '_x000D_' do
-    let(:path) { 'test/files/x000D.xlsx' }
-    it 'does not contain _x000D_' do
-      expect(subject.cell(2, 9)).not_to include('_x000D_')
-    end
-  end
-
-  describe 'opening a file with a chart sheet' do
-    let(:path) { 'test/files/chart_sheet.xlsx' }
-    it 'should not raise' do
-      expect{ subject }.to_not raise_error
-    end
-  end
-
-  describe 'opening a file with white space in the styles.xml' do
-    let(:path) { 'test/files/style_nodes_with_white_spaces.xlsx' }
-    subject(:xlsx) do
-      Roo::Spreadsheet.open(path, expand_merged_ranges: true, extension: :xlsx)
-    end
-    it 'should properly recognize formats' do
-      expect(subject.sheet(0).excelx_format(2,1)).to eq 'm/d/yyyy" "h:mm:ss" "AM/PM'
     end
   end
 end

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -480,34 +480,67 @@ describe Roo::Excelx do
   end
 
   describe '#html_strings' do
-    let(:path) { 'test/files/html_strings_formatting.xlsx' }
-
-    it 'returns the expected result' do
-      expect(subject.excelx_value(1, 1, "Sheet1")).to eq "This has no formatting."
-      expect(subject.excelx_value(2, 1, "Sheet1")).to eq "<html>This has<b> bold </b>formatting.</html>"
-      expect(subject.excelx_value(2, 2, "Sheet1")).to eq "<html>This has <i>italics</i> formatting.</html>"
-      expect(subject.excelx_value(2, 3, "Sheet1")).to eq "<html>This has <u>underline</u> format.</html>"
-      expect(subject.excelx_value(2, 4, "Sheet1")).to eq "<html>Superscript. x<sup>123</sup></html>"
-      expect(subject.excelx_value(2, 5, "Sheet1")).to eq "<html>SubScript.  T<sub>j</sub></html>"
-
-      expect(subject.excelx_value(3, 1, "Sheet1")).to eq "<html>Bold, italics <b><i>together</i></b>.</html>"
-      expect(subject.excelx_value(3, 2, "Sheet1")).to eq "<html>Bold, Underline <b><u>together</u></b>.</html>"
-      expect(subject.excelx_value(3, 3, "Sheet1")).to eq "<html>Bold, Superscript. <b>x</b><sup><b>N</b></sup></html>"
-      expect(subject.excelx_value(3, 4, "Sheet1")).to eq "<html>Bold, Subscript. <b>T</b><sub><b>abc</b></sub></html>"
-      expect(subject.excelx_value(3, 5, "Sheet1")).to eq "<html>Italics, Underline <i><u>together</u></i>.</html>"
-      expect(subject.excelx_value(3, 6, "Sheet1")).to eq "<html>Italics, Superscript.  <i>X</i><sup><i>abc</i></sup></html>"
-      expect(subject.excelx_value(3, 7, "Sheet1")).to eq "<html>Italics, Subscript.  <i>B</i><sub><i>efg</i></sub></html>"
-      expect(subject.excelx_value(4, 1, "Sheet1")).to eq "<html>Bold, italics underline,<b><i><u> together</u></i></b>.</html>"
-      expect(subject.excelx_value(4, 2, "Sheet1")).to eq "<html>Bold, italics, superscript. <b>X</b><sup><b><i>abc</i></b></sup><b><i>123</i></b></html>"
-      expect(subject.excelx_value(4, 3, "Sheet1")).to eq "<html>Bold, Italics, subscript. <b><i>Mg</i></b><sub><b><i>ha</i></b></sub><b><i>2</i></b></html>"
-      expect(subject.excelx_value(4, 4, "Sheet1")).to eq "<html>Bold, Underline, superscript. <b><u>AB</u></b><sup><b><u>C12</u></b></sup><b><u>3</u></b></html>"
-      expect(subject.excelx_value(4, 5, "Sheet1")).to eq "<html>Bold, Underline, subscript. <b><u>Good</u></b><sub><b><u>XYZ</u></b></sub></html>"
-      expect(subject.excelx_value(4, 6, "Sheet1")).to eq "<html>Italics, Underline, superscript. <i><u>Up</u></i><sup><i><u>swing</u></i></sup></html>"
-      expect(subject.excelx_value(4, 7, "Sheet1")).to eq "<html>Italics, Underline, subscript. <i><u>T</u></i><sub><i><u>swing</u></i></sub></html>"
-      expect(subject.excelx_value(5, 1, "Sheet1")).to eq "<html>Bold, italics, underline, superscript.  <b><i><u>GHJK</u></i></b><sup><b><i><u>190</u></i></b></sup><b><i><u>4</u></i></b></html>"
-      expect(subject.excelx_value(5, 2, "Sheet1")).to eq "<html>Bold, italics, underline, subscript. <b><i><u>Mike</u></i></b><sub><b><i><u>drop</u></i></b></sub></html>"
-      expect(subject.excelx_value(6, 1, "Sheet1")).to eq "See that regular html tags do not create html tags.\n<ol>\n  <li> Denver Broncos </li>\n  <li> Carolina Panthers </li>\n  <li> New England Patriots</li>\n  <li>Arizona Panthers</li>\n</ol>"
-      expect(subject.excelx_value(7, 1, "Sheet1")).to eq "<html>Does create html tags when formatting is used..\n<ol>\n  <li> <b>Denver Broncos</b> </li>\n  <li> <i>Carolina Panthers </i></li>\n  <li> <u>New England Patriots</u></li>\n  <li>Arizona Panthers</li>\n</ol></html>"
+    describe "HTML Parsing Enabling" do
+      let(:path) { 'test/files/html_strings_formatting.xlsx' }
+  
+      it 'returns the expected result' do
+        expect(subject.excelx_value(1, 1, "Sheet1")).to eq("This has no formatting.")
+        expect(subject.excelx_value(2, 1, "Sheet1")).to eq("<html>This has<b> bold </b>formatting.</html>")
+        expect(subject.excelx_value(2, 2, "Sheet1")).to eq("<html>This has <i>italics</i> formatting.</html>")
+        expect(subject.excelx_value(2, 3, "Sheet1")).to eq("<html>This has <u>underline</u> format.</html>")
+        expect(subject.excelx_value(2, 4, "Sheet1")).to eq("<html>Superscript. x<sup>123</sup></html>")
+        expect(subject.excelx_value(2, 5, "Sheet1")).to eq("<html>SubScript.  T<sub>j</sub></html>")
+  
+        expect(subject.excelx_value(3, 1, "Sheet1")).to eq("<html>Bold, italics <b><i>together</i></b>.</html>")
+        expect(subject.excelx_value(3, 2, "Sheet1")).to eq("<html>Bold, Underline <b><u>together</u></b>.</html>")
+        expect(subject.excelx_value(3, 3, "Sheet1")).to eq("<html>Bold, Superscript. <b>x</b><sup><b>N</b></sup></html>")
+        expect(subject.excelx_value(3, 4, "Sheet1")).to eq("<html>Bold, Subscript. <b>T</b><sub><b>abc</b></sub></html>")
+        expect(subject.excelx_value(3, 5, "Sheet1")).to eq("<html>Italics, Underline <i><u>together</u></i>.</html>")
+        expect(subject.excelx_value(3, 6, "Sheet1")).to eq("<html>Italics, Superscript.  <i>X</i><sup><i>abc</i></sup></html>")
+        expect(subject.excelx_value(3, 7, "Sheet1")).to eq("<html>Italics, Subscript.  <i>B</i><sub><i>efg</i></sub></html>")
+        expect(subject.excelx_value(4, 1, "Sheet1")).to eq("<html>Bold, italics underline,<b><i><u> together</u></i></b>.</html>")
+        expect(subject.excelx_value(4, 2, "Sheet1")).to eq("<html>Bold, italics, superscript. <b>X</b><sup><b><i>abc</i></b></sup><b><i>123</i></b></html>")
+        expect(subject.excelx_value(4, 3, "Sheet1")).to eq("<html>Bold, Italics, subscript. <b><i>Mg</i></b><sub><b><i>ha</i></b></sub><b><i>2</i></b></html>")
+        expect(subject.excelx_value(4, 4, "Sheet1")).to eq("<html>Bold, Underline, superscript. <b><u>AB</u></b><sup><b><u>C12</u></b></sup><b><u>3</u></b></html>")
+        expect(subject.excelx_value(4, 5, "Sheet1")).to eq("<html>Bold, Underline, subscript. <b><u>Good</u></b><sub><b><u>XYZ</u></b></sub></html>")
+        expect(subject.excelx_value(4, 6, "Sheet1")).to eq("<html>Italics, Underline, superscript. <i><u>Up</u></i><sup><i><u>swing</u></i></sup></html>")
+        expect(subject.excelx_value(4, 7, "Sheet1")).to eq("<html>Italics, Underline, subscript. <i><u>T</u></i><sub><i><u>swing</u></i></sub></html>")
+        expect(subject.excelx_value(5, 1, "Sheet1")).to eq("<html>Bold, italics, underline, superscript.  <b><i><u>GHJK</u></i></b><sup><b><i><u>190</u></i></b></sup><b><i><u>4</u></i></b></html>")
+        expect(subject.excelx_value(5, 2, "Sheet1")).to eq("<html>Bold, italics, underline, subscript. <b><i><u>Mike</u></i></b><sub><b><i><u>drop</u></i></b></sub></html>")
+        expect(subject.excelx_value(6, 1, "Sheet1")).to eq("See that regular html tags do not create html tags.\n<ol>\n  <li> Denver Broncos </li>\n  <li> Carolina Panthers </li>\n  <li> New England Patriots</li>\n  <li>Arizona Panthers</li>\n</ol>")
+        expect(subject.excelx_value(7, 1, "Sheet1")).to eq("<html>Does create html tags when formatting is used..\n<ol>\n  <li> <b>Denver Broncos</b> </li>\n  <li> <i>Carolina Panthers </i></li>\n  <li> <u>New England Patriots</u></li>\n  <li>Arizona Panthers</li>\n</ol></html>")
+      end
+    end
+    describe "HTML Parsing Disabled" do
+      let(:path) { 'test/files/html_strings_formatting.xlsx' }
+  
+      it 'returns the expected result' do
+        expect(subject.excelx_value(1, 1, "Sheet1")).to eq("This has no formatting.")
+        expect(subject.excelx_value(2, 1, "Sheet1")).to eq("This has bold formatting.")
+        expect(subject.excelx_value(2, 2, "Sheet1")).to eq("This has italics formatting.")
+        expect(subject.excelx_value(2, 3, "Sheet1")).to eq("This has underline format.")
+        expect(subject.excelx_value(2, 4, "Sheet1")).to eq("Superscript. x123<")
+        expect(subject.excelx_value(2, 5, "Sheet1")).to eq("SubScript.  Tj")
+  
+        expect(subject.excelx_value(3, 1, "Sheet1")).to eq("Bold, italics together.")
+        expect(subject.excelx_value(3, 2, "Sheet1")).to eq("Bold, Underline together.")
+        expect(subject.excelx_value(3, 3, "Sheet1")).to eq("Bold, Superscript. xN")
+        expect(subject.excelx_value(3, 4, "Sheet1")).to eq("Bold, Subscript. Tabc")
+        expect(subject.excelx_value(3, 5, "Sheet1")).to eq("Italics, Underline together.")
+        expect(subject.excelx_value(3, 6, "Sheet1")).to eq("Italics, Superscript.  Xabc")
+        expect(subject.excelx_value(3, 7, "Sheet1")).to eq("Italics, Subscript.  Befg")
+        expect(subject.excelx_value(4, 1, "Sheet1")).to eq("Bold, italics underline, together.")
+        expect(subject.excelx_value(4, 2, "Sheet1")).to eq("Bold, italics, superscript. Xabc123")
+        expect(subject.excelx_value(4, 3, "Sheet1")).to eq("Bold, Italics, subscript. Mgha2")
+        expect(subject.excelx_value(4, 4, "Sheet1")).to eq("Bold, Underline, superscript. ABC123")
+        expect(subject.excelx_value(4, 5, "Sheet1")).to eq("Bold, Underline, subscript. GoodXYZ")
+        expect(subject.excelx_value(4, 6, "Sheet1")).to eq("Italics, Underline, superscript. Upswing")
+        expect(subject.excelx_value(4, 7, "Sheet1")).to eq("Italics, Underline, subscript. Tswing")
+        expect(subject.excelx_value(5, 1, "Sheet1")).to eq("Bold, italics, underline, superscript.  GHJK1904")
+        expect(subject.excelx_value(5, 2, "Sheet1")).to eq("Bold, italics, underline, subscript. Mikedrop")
+        expect(subject.excelx_value(6, 1, "Sheet1")).to eq("See that regular html tags do not create html tags.\n<ol>\n  <li> Denver Broncos </li>\n  <li> Carolina Panthers </li>\n  <li> New England Patriots</li>\n  <li>Arizona Panthers</li>\n</ol>")
+        expect(subject.excelx_value(7, 1, "Sheet1")).to eq("Does create html tags when formatting is used..\n<ol>\n  <li> Denver Broncos </li>\n  <li> Carolina Panthers </li>\n  <li> New England Patriots</li>\n  <li>Arizona Panthers</li>\n</ol>")
+      end
     end
   end
 


### PR DESCRIPTION
From the initial pull request on HTML importing

[Comment on Disable HTML](https://github.com/roo-rb/roo/pull/278#issuecomment-301041264),

this is an attempt to add the ability to disable HTML injection.

To disable, the desired function would be:
Roo::Excelx.new(path, disable_html_injection: true)