### PR TITLE
Fixing the parsing of date offsets between 01-01-1900 and 28-02-1900

### DIFF
--- a/lib/roo/excelx/cell/date.rb
+++ b/lib/roo/excelx/cell/date.rb
@@ -17,7 +17,7 @@ module Roo
         private
 
         def create_date(base_date, value)
-          date = base_date + value.to_i
+          date = add_offset_to_base_date(base_date, value.to_i)
           yyyy, mm, dd = date.strftime('%Y-%m-%d').split('-')
 
           ::Date.new(yyyy.to_i, mm.to_i, dd.to_i)

--- a/lib/roo/excelx/cell/datetime.rb
+++ b/lib/roo/excelx/cell/datetime.rb
@@ -46,6 +46,8 @@ module Roo
 
         private
 
+        EPOCH_1900 = Roo::Excelx::Workbook::EPOCH_1900
+
         def parse_date_or_time_format(part)
           date_regex = /(?<date>[dmy]+[\-\/][dmy]+([\-\/][dmy]+)?)/
           time_regex = /(?<time>(\[?[h]\]?+:)?[m]+(:?ss|:?s)?)/
@@ -93,11 +95,24 @@ module Roo
         }
 
         def create_datetime(base_date, value)
-          date = base_date + value.to_f.round(6)
+          date = add_offset_to_base_date(base_date, value.to_f.round(6))
           datetime_string = date.strftime('%Y-%m-%d %H:%M:%S.%N')
           t = round_datetime(datetime_string)
 
           ::DateTime.civil(t.year, t.month, t.day, t.hour, t.min, t.sec)
+        end
+
+        def add_offset_to_base_date(base_date, offset)
+          # Adjust for Excel erroneously treating 1900 as a leap year
+          if EPOCH_1900 == base_date
+            offset -= 1
+
+            if offset > 58
+              offset -= 1
+            end
+          end
+
+          base_date + offset
         end
 
         def round_datetime(datetime_string)

--- a/lib/roo/excelx/workbook.rb
+++ b/lib/roo/excelx/workbook.rb
@@ -38,21 +38,19 @@ module Roo
         end]
       end
 
+      EPOCH_1900 = Date.new(1900, 1, 1).freeze
+      EPOCH_1904 = Date.new(1904, 1, 1).freeze
+
       def base_date
         @base_date ||=
-        begin
-          # Default to 1900 (minus one day due to excel quirk) but use 1904 if
-          # it's set in the Workbook's workbookPr
-          # http://msdn.microsoft.com/en-us/library/ff530155(v=office.12).aspx
-          result = Date.new(1899, 12, 30) # default
-          doc.css('workbookPr[date1904]').each do |workbookPr|
-            if workbookPr['date1904'] =~ /true|1/i
-              result = Date.new(1904, 01, 01)
-              break
-            end
+          begin
+            # Default to 1900 (minus one day due to excel quirk) but use 1904 if
+            # it's set in the Workbook's workbookPr
+            # http://msdn.microsoft.com/en-us/library/ff530155(v=office.12).aspx
+            doc.css('workbookPr[date1904]').any? {|workbookPr| workbookPr['date1904'] =~ /true|1/i} ?
+              EPOCH_1904 :
+              EPOCH_1900
           end
-          result
-        end
       end
     end
   end

--- a/test/excelx/cell/test_date.rb
+++ b/test/excelx/cell/test_date.rb
@@ -6,11 +6,11 @@ class TestRooExcelxCellDate < Minitest::Test
   end
 
   def base_date
-    ::Date.new(1899, 12, 30)
+    EPOCH_1900
   end
 
   def base_date_1904
-    ::Date.new(1904, 01, 01)
+    EPOCH_1904
   end
 
   def test_handles_1904_base_date

--- a/test/excelx/cell/test_datetime.rb
+++ b/test/excelx/cell/test_datetime.rb
@@ -40,6 +40,6 @@ class TestRooExcelxCellDateTime < Minitest::Test
   end
 
   def base_date
-    Date.new(1899, 12, 30)
+    EPOCH_1900
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -154,3 +154,6 @@ def skip_jruby_incompatible_test
   msg = "This test uses a feature incompatible with JRuby"
   skip(msg) if defined?(JRUBY_VERSION)
 end
+
+EPOCH_1900 = Roo::Excelx::Workbook::EPOCH_1900
+EPOCH_1904 = Roo::Excelx::Workbook::EPOCH_1904


### PR DESCRIPTION
Hi Folks:

The reason of this PR is because in BeBanjo we had problems with the range of dates between 01-01-1900 and 28-02-1900 in an excel file.

The conversion of this range was wrong in the gem and it subtracted one day.