### PR TITLE
Handled case where cell value is infinity

### DIFF
--- a/lib/roo/formatters/csv.rb
+++ b/lib/roo/formatters/csv.rb
@@ -59,6 +59,7 @@ module Roo
           when Integer
             onecell.to_s
           when Float
+            return "infinity" if onecell == Float::INFINITY
             if onecell == onecell.to_i
               onecell.to_i.to_s
             else

--- a/lib/roo/formatters/csv.rb
+++ b/lib/roo/formatters/csv.rb
@@ -47,6 +47,7 @@ module Roo
           onecell = self.sheet_for(sheet).cells[[row, col]].formatted_value
           %("#{onecell.gsub('"', '""').downcase}")
         when :float, :percentage
+          return "0" if onecell == Float::INFINITY
           if onecell == onecell.to_i
             onecell.to_i.to_s
           else
@@ -59,7 +60,6 @@ module Roo
           when Integer
             onecell.to_s
           when Float
-            return "infinity" if onecell == Float::INFINITY
             if onecell == onecell.to_i
               onecell.to_i.to_s
             else


### PR DESCRIPTION
In the case that the cell value is supposed to contain a float, yet was calculated improperly and equals infinity, the .to_i method in the csv formatter file will fail.  