### PR TITLE
Cell::Time downcase format before formatting

### DIFF
--- a/lib/roo/excelx/cell/time.rb
+++ b/lib/roo/excelx/cell/time.rb
@@ -16,7 +16,7 @@ module Roo
         end
 
         def formatted_value
-          formatter = @format.gsub(/#{TIME_FORMATS.keys.join('|')}/, TIME_FORMATS)
+          formatter = @format.downcase.gsub(/#{TIME_FORMATS.keys.join('|')}/, TIME_FORMATS)
           @datetime.strftime(formatter)
         end
 

--- a/test/excelx/cell/test_time.rb
+++ b/test/excelx/cell/test_time.rb
@@ -16,7 +16,8 @@ class TestRooExcelxCellTime < Minitest::Test
       ['h:mm:ss', '1:48:09'],
       ['mm:ss', '48:09'],
       ['[h]:mm:ss', '[1]:48:09'],
-      ['mmss.0', '4809.0'] # Cell::Time always get rounded to the nearest second.
+      ['mmss.0', '4809.0'], # Cell::Time always get rounded to the nearest second.
+      ['HH:MM:SS', '01:48:09'], # A capitalized example
     ].each do |style_format, result|
       cell = roo_time.new(value, nil, [:numeric_or_formula, style_format], 6, nil, base_date, nil)
       assert_equal result, cell.formatted_value, "Style=#{style_format} is not properly formatted"


### PR DESCRIPTION
In the case the format is on upcase we must downcase before trying to get convert to a strftime format expression. Is the same the library is doing on `DateTime` cells [here](https://github.com/roo-rb/roo/blob/62b033cf8d7e06e43ce1a35c9a92f37deff6a088/lib/roo/excelx/cell/datetime.rb#L35)