### PR TITLE
Allow missing columns #421

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -282,7 +282,6 @@ class Roo::Base
 
   def each(options = {})
     return to_enum(:each, options) unless block_given?
-
     if options.empty?
       1.upto(last_row) do |line|
         yield row(line)
@@ -314,8 +313,7 @@ class Roo::Base
     each do |row|
       line_no += 1
       headers = query.map { |q| row.grep(q)[0] }.compact
-
-      if headers.length == query.length
+      if headers.length > 1
         @header_line = line_no
         return return_headers ? headers : line_no
       elsif line_no > 100
@@ -494,9 +492,16 @@ class Roo::Base
   end
 
   def set_headers(hash = {})
+    # hash contains the header search and column name map
+
     # try to find header row with all values or give an error
     # then create new hash by indexing strings and keeping integers for header array
+
+    # @headers contains the header row from the spreadsheet
     @headers = row_with(hash.values, true)
+
+    # REJECT COLUMN NAMES FROM HASH THAT DO NOT EXIST
+    hash.reject!{ |k,v| @headers.grep(v).empty?}
     @headers = Hash[hash.keys.zip(@headers.map { |x| header_index(x) })]
   end
 

--- a/roo.gemspec
+++ b/roo.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'nokogiri', '~> 1'
-  spec.add_dependency 'rubyzip', '>= 1.2.1', '< 2.0.0'
+  spec.add_dependency 'rubyzip', '>= 1.1.0'
 
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'


### PR DESCRIPTION
This PR will allow missing columns without causing an exception.  This provides very flexible importing where a column map with regex may be specified, but parsing will continue successfully if the imported spreadsheet does not contain all of the expected columns.