### PR TITLE
Add support for "1e6" as scientific notation

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -21,7 +21,7 @@ module Roo
           when /\.0/
             Float(number)
           else
-            (number.include?('.') || (/\A[-+]?\d+E[-+]\d+\z/i =~ number)) ? Float(number) : Integer(number)
+            (number.include?('.') || (/\A[-+]?\d+E[-+]?\d+\z/i =~ number)) ? Float(number) : Integer(number)
           end
         end
 

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -25,6 +25,11 @@ class TestRooExcelxCellNumber < Minitest::Test
     assert_kind_of(Float, cell.value)
   end
 
+  def test_very_simple_scientific_notation
+    cell = Roo::Excelx::Cell::Number.new '1e6', nil, ['0'], nil, nil, nil
+    assert_kind_of(Float, cell.value)
+  end
+
   def test_percent
     cell = Roo::Excelx::Cell::Number.new '42.1', nil, ['0.00%'], nil, nil, nil
     assert_kind_of(Float, cell.value)


### PR DESCRIPTION
We discovered a `xlsx` file in the wild recently using cell data with the format `<c r="A1" s="1"><v>1e6</v></c>`  to mean `1000000`. I've not been able to determine what generated this xml or if it is valid according to the spec but this PR adds support for this format to the existing code which handles scientific notation. 

The oldest version of Excel i have handy (Excel for Mac 2011, v 14.7.3) would have generated `<c r="A1" s="1"><v>1E+06</v></c>` in this case.

A new unit test is added as well.