### PR TITLE
Fixes .to_csv bug after updating cells in Excelx sheets

### DIFF
--- a/lib/roo/excelx/cell.rb
+++ b/lib/roo/excelx/cell.rb
@@ -11,8 +11,12 @@ require 'roo/excelx/cell/time'
 module Roo
   class Excelx
     class Cell
+      extend Forwardable
+
       attr_reader :formula, :value, :excelx_type, :excelx_value, :style, :hyperlink, :coordinate
       attr_writer :value
+
+      delegate :empty? => :@value
 
       # DEPRECATED: Please use Cell.create_cell instead.
       def initialize(value, type, formula, excelx_type, excelx_value, style, hyperlink, base_date, coordinate)

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -214,6 +214,16 @@ describe Roo::Excelx do
     end
   end
 
+  describe '#to_csv' do
+    let(:path) { 'test/files/numbers1.xlsx' }
+
+    it 'continues working after updating a cell' do
+      subject.set(1, 2, 'Foo', 'Sheet5')
+
+      expect { subject.to_csv(nil, nil, 'Sheet5') }.not_to raise_error
+    end
+  end
+
   describe '#formula' do
     let(:path) { 'test/files/formula.xlsx' }
 


### PR DESCRIPTION
I was encountering an error where updating a cell on an Excelx file causes .to_csv to stop working, raising an `undefined method empty?` error. I think the longer term solution is to migrate `.set` to use `Cell.create_new` as per the deprecation warning - I'm not yet familiar enough with the internals of this project to take that on, so here's a fix that got this working for me again in the interim.