### PR TITLE
Update failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - 2.5
   - ruby-head
   - jruby-9.1.6.0
+env:
+  - LONG_RUN=true
+  - LONG_RUN=false
 matrix:
   include:
     - rvm: 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - jruby-9.1.6.0
 env:
   - LONG_RUN=true
-  - LONG_RUN=false
 matrix:
   include:
     - rvm: 2.0

--- a/test/roo/test_base.rb
+++ b/test/roo/test_base.rb
@@ -63,11 +63,11 @@ class TestRooBase < Minitest::Test
       workbook.default_sheet = workbook.sheets.first
       result = workbook.find 20
       assert result
-      assert_equal "Brief aus dem Sekretariat", result[0]["TITEL"]
+      assert_equal "Brief aus dem Sekretariat", result[0]
 
       result = workbook.find 22
       assert result
-      assert_equal "Brief aus dem Skretariat. Tagung in Amberg/Opf.", result[0]["TITEL"]
+      assert_equal "Brief aus dem Skretariat. Tagung in Amberg/Opf.", result[0]
     end
   end
 

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -339,21 +339,21 @@ class TestRoo < Minitest::Test
 
   # compare large spreadsheets
   def test_compare_large_spreadsheets
-    # problematisch, weil Formeln in Excel nicht unterstützt werden
     skip_long_test
     qq = Roo::OpenOffice.new(File.join('test', 'files', "Bibelbund.ods"))
-    with_each_spreadsheet(:name=>'Bibelbund') do |oo|
+    with_each_spreadsheet(name: 'Bibelbund') do |oo|
       oo.sheets.each do |sh|
         oo.first_row.upto(oo.last_row) do |row|
           oo.first_column.upto(oo.last_column) do |col|
-            c1 = qq.cell(row,col,sh)
+            c1 = qq.cell(row, col, sh)
             c1.force_encoding("UTF-8") if c1.class == String
             c2 = oo.cell(row,col,sh)
             c2.force_encoding("UTF-8") if c2.class == String
             next if c1.nil? && c2.nil?
+
             assert_equal c1, c2, "diff in #{sh}/#{row}/#{col}}"
-            assert_equal qq.celltype(row,col,sh), oo.celltype(row,col,sh)
-            assert_equal qq.formula?(row,col,sh), oo.formula?(row,col,sh) if oo.class != Roo::Excelx
+            assert_equal qq.celltype(row, col, sh), oo.celltype(row, col, sh)
+            assert_equal qq.formula?(row, col, sh), oo.formula?(row, col, sh)
           end
         end
       end

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -341,9 +341,8 @@ class TestRoo < Minitest::Test
   def test_compare_large_spreadsheets
     # problematisch, weil Formeln in Excel nicht unterstützt werden
     skip_long_test
-    qq = Roo::OpenOffice.new(File.join('test',"Bibelbund.ods"))
+    qq = Roo::OpenOffice.new(File.join('test', 'files', "Bibelbund.ods"))
     with_each_spreadsheet(:name=>'Bibelbund') do |oo|
-      # p "comparing Bibelbund.ods with #{oo.class}"
       oo.sheets.each do |sh|
         oo.first_row.upto(oo.last_row) do |row|
           oo.first_column.upto(oo.last_column) do |col|
@@ -351,9 +350,10 @@ class TestRoo < Minitest::Test
             c1.force_encoding("UTF-8") if c1.class == String
             c2 = oo.cell(row,col,sh)
             c2.force_encoding("UTF-8") if c2.class == String
+            next if c1.nil? && c2.nil?
             assert_equal c1, c2, "diff in #{sh}/#{row}/#{col}}"
             assert_equal qq.celltype(row,col,sh), oo.celltype(row,col,sh)
-            assert_equal qq.formula?(row,col,sh), oo.formula?(row,col,sh) if oo.class != Roo::Excel
+            assert_equal qq.formula?(row,col,sh), oo.formula?(row,col,sh) if oo.class != Roo::Excelx
           end
         end
       end


### PR DESCRIPTION
When tests were run with the LONG_RUN flag set to true, a couple of them
were failing. Those tests will no longer fail.