### PR TITLE
Remove unnecessary cache hash for Roo::Excelx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 - Updated rubyzip version for fixing security issue. Now minimal version is 1.2.1
 
+### Deprecations
+- Roo::Excelx::Sheet#present_cells is deprecated [454](https://github.com/roo-rb/roo/pull/454)
+
 ## [2.7.1] 2017-01-03
 ### Fixed
 - Fixed regression where a CSV's encoding was being ignored [372](https://github.com/roo-rb/roo/pull/372)
@@ -49,7 +52,7 @@
 - Discard hyperlinks lookups to allow streaming parsing without loading whole files
 
 ## [2.4.0] 2016-05-14
-### Fixed  
+### Fixed
 - Fixed opening spreadsheets with charts [315](https://github.com/roo-rb/roo/pull/315)
 - Fixed memory issues for Roo::Utils.number_to_letter [308](https://github.com/roo-rb/roo/pull/308)
 - Fixed Roo::Excelx::Cell::Number to recognize floating point numbers [306](https://github.com/roo-rb/roo/pull/306)

--- a/lib/roo/excelx/cell/base.rb
+++ b/lib/roo/excelx/cell/base.rb
@@ -88,6 +88,10 @@ module Roo
         def empty?
           false
         end
+
+        def presence
+          empty? ? nil : self
+        end
       end
     end
   end

--- a/lib/roo/excelx/sheet.rb
+++ b/lib/roo/excelx/sheet.rb
@@ -22,10 +22,6 @@ module Roo
         @cells ||= @sheet.cells(@rels)
       end
 
-      def present_cells
-        @present_cells ||= cells.select { |_, cell| cell && !cell.empty? }
-      end
-
       # Yield each row as array of Excelx::Cell objects
       # accepts options max_rows (int) (offset by 1 for header),
       # pad_cells (boolean) and offset (int)
@@ -57,21 +53,21 @@ module Roo
 
       # returns the number of the first non-empty row
       def first_row
-        @first_row ||= present_cells.keys.map { |row, _| row }.min
+        @first_row ||= first_last_row_col[:first_row]
       end
 
       def last_row
-        @last_row ||= present_cells.keys.map { |row, _| row }.max
+        @last_row ||= first_last_row_col[:last_row]
       end
 
       # returns the number of the first non-empty column
       def first_column
-        @first_column ||= present_cells.keys.map { |_, col| col }.min
+        @first_column ||= first_last_row_col[:first_column]
       end
 
       # returns the number of the last non-empty column
       def last_column
-        @last_column ||= present_cells.keys.map { |_, col| col }.max
+        @last_column ||= first_last_row_col[:last_column]
       end
 
       def excelx_format(key)
@@ -112,6 +108,35 @@ module Roo
         pad = []
         (cell.coordinate.column - 1 - last_column).times { pad << nil }
         pad
+      end
+
+      def first_last_row_col
+        @first_last_row_col ||= begin
+          first_row = last_row = first_col = last_col = nil
+
+          cells.each do |(row, col), cell|
+            if cell && !cell.empty?
+              first_row ||= row
+              last_row ||= row
+              first_col ||= col
+              last_col ||= col
+
+              if row > last_row
+                last_row = row
+              elsif row < first_row
+                first_row = row
+              end
+
+              if col > last_col
+                last_col = col
+              elsif col < first_col
+                first_col = col
+              end
+            end
+          end
+
+          {first_row: first_row, last_row: last_row, first_column: first_col, last_column: last_col}
+        end
       end
     end
   end

--- a/lib/roo/excelx/sheet.rb
+++ b/lib/roo/excelx/sheet.rb
@@ -22,6 +22,19 @@ module Roo
         @cells ||= @sheet.cells(@rels)
       end
 
+      def present_cells
+        @present_cells ||= begin
+          warn %{
+[DEPRECATION] present_cells is deprecated. Alternate:
+  with activesupport    => cells[key].presence
+  without activesupport
+    (ruby -v >= 2.3)      => cells[key]&.presence
+    (ruby -v < 2.3)       => (cell = cells[key]) && cell.presence
+          }
+          cells.select { |_, cell| cell && cell.presence }
+        end
+      end
+
       # Yield each row as array of Excelx::Cell objects
       # accepts options max_rows (int) (offset by 1 for header),
       # pad_cells (boolean) and offset (int)
@@ -115,23 +128,22 @@ module Roo
           first_row = last_row = first_col = last_col = nil
 
           cells.each do |(row, col), cell|
-            if cell && !cell.empty?
-              first_row ||= row
-              last_row ||= row
-              first_col ||= col
-              last_col ||= col
+            next unless cell && cell.presence
+            first_row ||= row
+            last_row ||= row
+            first_col ||= col
+            last_col ||= col
 
-              if row > last_row
-                last_row = row
-              elsif row < first_row
-                first_row = row
-              end
+            if row > last_row
+              last_row = row
+            elsif row < first_row
+              first_row = row
+            end
 
-              if col > last_col
-                last_col = col
-              elsif col < first_col
-                first_col = col
-              end
+            if col > last_col
+              last_col = col
+            elsif col < first_col
+              first_col = col
             end
           end
 

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -40,12 +40,13 @@ module Roo
         return [] unless row_xml
         row_xml.children.each do |cell_element|
           # If you're sure you're not going to need this hyperlinks you can discard it
+          coordinate = ::Roo::Utils.extract_coordinate(cell_element[COMMON_STRINGS[:r]])
           hyperlinks = unless @options[:no_hyperlinks]
-                         key = ::Roo::Utils.ref_to_key(cell_element[COMMON_STRINGS[:r]])
+                         key = coordinate.to_a
                          hyperlinks(@relationships)[key]
                        end
 
-          yield cell_from_xml(cell_element, hyperlinks)
+          yield cell_from_xml(cell_element, hyperlinks, coordinate)
         end
       end
 
@@ -81,8 +82,8 @@ module Roo
       #    # => <Excelx::Cell::String>
       #
       # Returns a type of <Excelx::Cell>.
-      def cell_from_xml(cell_xml, hyperlink)
-        coordinate = ::Roo::Utils.extract_coordinate(cell_xml[COMMON_STRINGS[:r]])
+      def cell_from_xml(cell_xml, hyperlink, coordinate=nil)
+        coordinate ||= ::Roo::Utils.extract_coordinate(cell_xml[COMMON_STRINGS[:r]])
         cell_xml_children = cell_xml.children
         return Excelx::Cell::Empty.new(coordinate) if cell_xml_children.empty?
 
@@ -196,8 +197,9 @@ module Roo
       def extract_cells(relationships)
         extracted_cells = {}
         doc.xpath('/worksheet/sheetData/row/c').each do |cell_xml|
-          key = ::Roo::Utils.ref_to_key(cell_xml[COMMON_STRINGS[:r]])
-          extracted_cells[key] = cell_from_xml(cell_xml, hyperlinks(relationships)[key])
+          coordinate = ::Roo::Utils.extract_coordinate(cell_xml[COMMON_STRINGS[:r]])
+          key = coordinate.to_a
+          extracted_cells[key] = cell_from_xml(cell_xml, hyperlinks(relationships)[key], coordinate)
         end
 
         expand_merged_ranges(extracted_cells) if @options[:expand_merged_ranges]

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -82,7 +82,7 @@ module Roo
       #    # => <Excelx::Cell::String>
       #
       # Returns a type of <Excelx::Cell>.
-      def cell_from_xml(cell_xml, hyperlink, coordinate=nil)
+      def cell_from_xml(cell_xml, hyperlink, coordinate = nil)
         coordinate ||= ::Roo::Utils.extract_coordinate(cell_xml[COMMON_STRINGS[:r]])
         cell_xml_children = cell_xml.children
         return Excelx::Cell::Empty.new(coordinate) if cell_xml_children.empty?

--- a/lib/roo/utils.rb
+++ b/lib/roo/utils.rb
@@ -4,13 +4,7 @@ module Roo
 
     LETTERS = ('A'..'Z').to_a
 
-    def extract_coordinate(str)
-      str = str.freeze
-      @extract_coordinate ||= {}
-      @extract_coordinate[str] ||= extract_coord(str)
-    end
-
-    def extract_coord(s)
+    def extract_coord(s, klass = Excelx::Coordinate)
       num = letter_num = 0
       num_only = false
 
@@ -27,11 +21,18 @@ module Roo
         end
       end
       fail ArgumentError if letter_num == 0 || !num_only
-      Excelx::Coordinate.new(num,letter_num)
+
+      if klass == Array
+        [num, letter_num]
+      else
+        klass.new(num, letter_num)
+      end
     end
 
+    alias_method :extract_coordinate, :extract_coord
+
     def split_coordinate(str)
-      extract_coordinate(str).to_a
+      extract_coord(str, Array)
     end
 
     alias_method :ref_to_key, :split_coordinate

--- a/test/excelx/cell/test_base.rb
+++ b/test/excelx/cell/test_base.rb
@@ -25,6 +25,11 @@ class TestRooExcelxCellBase < Minitest::Test
     refute cell.empty?
   end
 
+  def test_presence
+    cell = base.new(value, nil, [], nil, nil, nil)
+    assert_equal cell, cell.presence
+  end
+
   def test_cell_type_is_formula
     formula = true
     cell = base.new(value, formula, [], nil, nil, nil)

--- a/test/excelx/cell/test_empty.rb
+++ b/test/excelx/cell/test_empty.rb
@@ -4,4 +4,15 @@ class TestRooExcelxCellEmpty < Minitest::Test
   def empty
     Roo::Excelx::Cell::Empty
   end
+
+  def test_empty?
+    cell = empty.new(nil)
+    assert_same  true, cell.empty?
+  end
+
+  def test_nil_presence
+    cell = empty.new(nil)
+    assert_nil cell.presence
+  end
+
 end

--- a/test/excelx/cell/test_string.rb
+++ b/test/excelx/cell/test_string.rb
@@ -25,4 +25,24 @@ class TestRooExcelxCellString < Minitest::Test
     cell = string.new '0', nil, nil, nil, nil
     assert_equal '0', cell.value
   end
+
+  def test_not_empty?
+    cell = string.new '1', nil, nil, nil, nil
+    assert_equal false, cell.empty?
+  end
+
+  def test_empty?
+    cell = string.new '', nil, nil, nil, nil
+    assert_equal true, cell.empty?
+  end
+
+  def test_presence
+    cell = string.new '1', nil, nil, nil, nil
+    assert_equal cell, cell.presence
+  end
+
+  def test_nil_presence
+    cell = string.new '', nil, nil, nil, nil
+    assert_nil cell.presence
+  end
 end


### PR DESCRIPTION
1. After https://github.com/roo-rb/roo/pull/434 we no longer need to cache Roo::Utils.extract_coordinate

2. Roo::Excelx::Sheet#present_cells is only used to calculate first/last row/column. Refactored code to avoid creation of present_cells hash.

Memory Profile Script
```
require 'roo'
require 'memory_profiler'

MemoryProfiler.report do
  excel = Roo::Excelx.new('test/files/Bibelbund.xlsx')
  (1..excel.last_row).each{|a| excel.row a}
end.pretty_print
```

Master
```
Total allocated: 42820054 bytes (545014 objects)
Total retained:  12833905 bytes (185969 objects)

allocated memory by gem
-----------------------------------
  24082522  roo/lib
  12173047  nokogiri-1.8.4
   6563085  rubyzip-1.2.2
      1184  tmpdir
       216  other

retained memory by gem
-----------------------------------
   9059622  roo/lib
   3773019  nokogiri-1.8.4
       792  rubyzip-1.2.2
       296  tmpdir
       176  other
```

Modified
```
Total allocated: 38800821 bytes (517025 objects)
Total retained:  9879455 bytes (157986 objects)

allocated memory by gem
-----------------------------------
  20951802  roo/lib
  11053807  nokogiri-1.8.4
   6793812  rubyzip-1.2.2
      1184  tmpdir
       216  other

retained memory by gem
-----------------------------------
   7224422  roo/lib
   2653779  nokogiri-1.8.4
       782  rubyzip-1.2.2
       296  tmpdir
       176  other
```

This PR also improves preformance by 5-12%