### PR TITLE
Removes link attr_reader from Cells

### DIFF
--- a/lib/roo/excelx/cell/base.rb
+++ b/lib/roo/excelx/cell/base.rb
@@ -74,11 +74,13 @@ module Roo
         # DEPRECATED: Please use link? instead.
         def hyperlink
           warn '[DEPRECATION] `hyperlink` is deprecated.  Please use `link?` instead.'
+          link?
         end
 
         # DEPRECATED: Please use link? instead.
         def link
           warn '[DEPRECATION] `link` is deprecated.  Please use `link?` instead.'
+          link?
         end
 
         # DEPRECATED: Please use cell_value instead.

--- a/lib/roo/excelx/cell/base.rb
+++ b/lib/roo/excelx/cell/base.rb
@@ -71,9 +71,14 @@ module Roo
           formatted_value
         end
 
-        # DEPRECATED: Please use link instead.
+        # DEPRECATED: Please use link? instead.
         def hyperlink
           warn '[DEPRECATION] `hyperlink` is deprecated.  Please use `link?` instead.'
+        end
+
+        # DEPRECATED: Please use link? instead.
+        def link
+          warn '[DEPRECATION] `link` is deprecated.  Please use `link?` instead.'
         end
 
         # DEPRECATED: Please use cell_value instead.

--- a/lib/roo/excelx/cell/base.rb
+++ b/lib/roo/excelx/cell/base.rb
@@ -73,7 +73,7 @@ module Roo
 
         # DEPRECATED: Please use link instead.
         def hyperlink
-          warn '[DEPRECATION] `hyperlink` is deprecated.  Please use `link` instead.'
+          warn '[DEPRECATION] `hyperlink` is deprecated.  Please use `link?` instead.'
         end
 
         # DEPRECATED: Please use cell_value instead.

--- a/lib/roo/excelx/cell/boolean.rb
+++ b/lib/roo/excelx/cell/boolean.rb
@@ -4,7 +4,7 @@ module Roo
   class Excelx
     class Cell
       class Boolean < Cell::Base
-        attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
+        attr_reader :value, :formula, :format, :cell_value, :coordinate
 
         attr_reader_with_default default_type: :boolean, cell_type: :boolean
 

--- a/lib/roo/excelx/cell/date.rb
+++ b/lib/roo/excelx/cell/date.rb
@@ -4,7 +4,7 @@ module Roo
   class Excelx
     class Cell
       class Date < Roo::Excelx::Cell::DateTime
-        attr_reader :value, :formula, :format, :cell_type, :cell_value, :link, :coordinate
+        attr_reader :value, :formula, :format, :cell_type, :cell_value, :coordinate
 
         attr_reader_with_default default_type: :date
 

--- a/lib/roo/excelx/cell/datetime.rb
+++ b/lib/roo/excelx/cell/datetime.rb
@@ -8,7 +8,7 @@ module Roo
       class DateTime < Cell::Base
         SECONDS_IN_DAY = 60 * 60 * 24
 
-        attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
+        attr_reader :value, :formula, :format, :cell_value, :coordinate
 
         attr_reader_with_default default_type: :datetime
 

--- a/lib/roo/excelx/cell/empty.rb
+++ b/lib/roo/excelx/cell/empty.rb
@@ -3,7 +3,7 @@ module Roo
   class Excelx
     class Cell
       class Empty < Cell::Base
-        attr_reader :value, :formula, :format, :cell_type, :cell_value, :hyperlink, :coordinate
+        attr_reader :value, :formula, :format, :cell_type, :cell_value, :coordinate
 
         attr_reader_with_default default_type: nil, style: nil
 

--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -4,7 +4,7 @@ module Roo
   class Excelx
     class Cell
       class Number < Cell::Base
-        attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
+        attr_reader :value, :formula, :format, :cell_value, :coordinate
 
         # FIXME: change default_type to number. This will break brittle tests.
         attr_reader_with_default default_type: :float

--- a/lib/roo/excelx/cell/string.rb
+++ b/lib/roo/excelx/cell/string.rb
@@ -2,7 +2,7 @@ module Roo
   class Excelx
     class Cell
       class String < Cell::Base
-        attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
+        attr_reader :value, :formula, :format, :cell_value, :coordinate
 
         attr_reader_with_default default_type: :string, cell_type: :string
 

--- a/lib/roo/excelx/cell/time.rb
+++ b/lib/roo/excelx/cell/time.rb
@@ -4,7 +4,7 @@ module Roo
   class Excelx
     class Cell
       class Time < Roo::Excelx::Cell::DateTime
-        attr_reader :value, :formula, :format, :cell_value, :link, :coordinate
+        attr_reader :value, :formula, :format, :cell_value, :coordinate
 
         attr_reader_with_default default_type: :time
 


### PR DESCRIPTION
In https://github.com/roo-rb/roo/pull/449 we remove the link instance variable (as we should have), but we left the reader's in which would always return nil. Added in deprecation warning to point people in the correct direction.