### PR TITLE
Option to skip allocation for empty cell. 

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -40,8 +40,9 @@ module Roo
       sheet_options = {}
       sheet_options[:expand_merged_ranges] = (options[:expand_merged_ranges] || false)
       sheet_options[:no_hyperlinks] = (options[:no_hyperlinks] || false)
+      sheet_options[:empty_cells] = (options[:empty_cells] || false)
       shared_options = {}
-        
+
       shared_options[:disable_html_wrapper] = (options[:disable_html_wrapper] || false)
       unless is_stream?(filename_or_stream)
         file_type_check(filename_or_stream, %w[.xlsx .xlsm], 'an Excel 2007', file_warning, packed)


### PR DESCRIPTION
Some excelx client (not sure which) creates a badly formatted file. I've attached one such file which when processed by roo will use a huge amount of memory.

Incase if you open & save such file in most of excelx client will fix the bad formated part (which can be observed with change in file size from ~5MB to ~37KB).
Since in production environment we can not add a constraint on excelx client used to generate the file, some badly formatted file will crash the server/process.

This changeset skips creation of empty cell and skips assignment of the key, value pair for such empty cell in the hash.

Benchmark result for the attached file.

Master:
~~~
Total allocated: 962056061 bytes (6385017 objects)
Total retained:  152051928 bytes (2114980 objects)

allocated memory by gem
-----------------------------------
 543193224  rubyzip-1.2.2
 263086610  roo/lib
 155773522  nokogiri-1.8.5
      1465  tmpdir
       880  racc
       320  weakref
        40  other

retained memory by gem
-----------------------------------
 152049144  roo/lib
      2000  nokogiri-1.8.5
       336  rubyzip-1.2.2
       208  tmpdir
       160  weakref
        80  racc

 20.050000   0.060000  20.110000 ( 20.127946)
~~~

After Patch:
~~~
Total allocated: 853271373 bytes (5337387 objects)
Total retained:  1362040 bytes (19720 objects)

allocated memory by gem
-----------------------------------
 543193224  rubyzip-1.2.2
 155773522  nokogiri-1.8.5
 154301922  roo/lib
      1465  tmpdir
       880  racc
       320  weakref
        40  other

retained memory by gem
-----------------------------------
   1359256  roo/lib
      2000  nokogiri-1.8.5
       336  rubyzip-1.2.2
       208  tmpdir
       160  weakref
        80  racc

  8.210000   0.060000   8.270000 (  8.276100)
~~~


**Need to discuss following things before we can go ahead with this:**
1.  What should be default value for newly added option (In long run default approach should be to not allocate empty cell). We need to determine if anyone depends upon allocation of empty cell which may break by default skipping option.
2.  Should this option be limited to non-streaming method. Since in streaming method objects (particulary empty cells and coordinate) can be GC'd it is not much of problem on current master (coordinates where meoimized in 2.7.1 so no GC). On side note each_row_streaming has pad_cells option which remove any incompatibility which could be introduced if we extend this option to streaming method.


[bad-formated-file.xlsx](https://github.com/roo-rb/roo/files/2459135/bad-formated-file.xlsx)

