### PR TITLE
Reduce array allocations in Roo::Utils.each_element

### DIFF
--- a/lib/roo/utils.rb
+++ b/lib/roo/utils.rb
@@ -81,8 +81,9 @@ module Roo
 
     # Yield each element of a given type ('row', 'c', etc.) to caller
     def each_element(path, elements)
+      elements = Array(elements)
       Nokogiri::XML::Reader(::File.open(path, 'rb'), nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).each do |node|
-        next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT && Array(elements).include?(node.name)
+        next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT && elements.include?(node.name)
         yield Nokogiri::XML(node.outer_xml).root if block_given?
       end
     end


### PR DESCRIPTION

### Summary
Taking some of the memory improvement changes from https://github.com/roo-rb/roo/pull/436. This reduces the number of array allocations in `Roo::Utils.each_element` when the `elements` argument is not an `Array`.

Memory profiling against the file `test/files/Bibelbund.xlsx`
```
Master
Total allocated: 42492082 bytes (555917 objects)
Total retained:  1295107 bytes (11631 objects)

allocated memory by gem
-----------------------------------
  21031985  roo-rb-roo/lib
  11231729  nokogiri-1.8.5
  10226503  rubyzip-1.2.2
      1433  tmpdir
       240  weakref
       192  other

This PR
Total allocated: 40143162 bytes (497194 objects)
Total retained:  1295107 bytes (11631 objects)

allocated memory by gem
-----------------------------------
  18683065  will89-roo/lib
  11231729  nokogiri-1.8.5
  10226503  rubyzip-1.2.2
      1433  tmpdir
       240  weakref
       192  other
```

This PR used about ~16% less memory when iterating through the file and allocated ~10% fewer objects.

```
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  #gem "roo", path: '/Users/will/repos/will89-roo'
  gem "roo", path: '/Users/will/repos/roo-rb-roo'
  gem "minitest"
  gem "memory_profiler"
end

require "roo"
require "minitest/autorun"
require "memory_profiler"

class BugTest < Minitest::Test
  def test_stuff
    # add your test here
    report = MemoryProfiler.report do
      sheet = Roo::Spreadsheet.open("/Users/will/repos/will89-roo/test/files/Bibelbund.xlsx", no_hyperlinks: true)
      sheet.each_row_streaming do |row|
        row[1]
      end
    end
    report.pretty_print
  end
end
```