### PR TITLE
TestHelper#start_local_server colliding port.

### DIFF
--- a/test/roo/test_csv.rb
+++ b/test/roo/test_csv.rb
@@ -15,7 +15,7 @@ class TestRooCSV < Minitest::Test
 
   def test_download_uri_with_query_string
     file = filename("simple_spreadsheet")
-    port = 12_344
+    port = 12_347
     url = "#{local_server(port)}/#{file}?query-param=value"
 
     start_local_server(file, port) do


### PR DESCRIPTION
fixes Net::ReadTimeout issue on old ruby version

https://travis-ci.org/roo-rb/roo/jobs/439124777#L613