### PR TITLE
Reduce array allocations in create_cell_from_value

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ end
 
 ```ruby
 xlsx.excelx_type(3, 'C')
-# => :numeric_or_formula
+# => "mm-dd-yy hh:mm"
 
 xlsx.cell(3, 'C')
 # => 600000383.0

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -41,7 +41,7 @@ module Roo
       sheet_options[:expand_merged_ranges] = (options[:expand_merged_ranges] || false)
       sheet_options[:no_hyperlinks] = (options[:no_hyperlinks] || false)
       shared_options = {}
-        
+
       shared_options[:disable_html_wrapper] = (options[:disable_html_wrapper] || false)
       unless is_stream?(filename_or_stream)
         file_type_check(filename_or_stream, %w[.xlsx .xlsm], 'an Excel 2007', file_warning, packed)
@@ -199,7 +199,6 @@ module Roo
     end
 
     # returns the internal type of an excel cell
-    # * :numeric_or_formula
     # * :string
     # Note: this is only available within the Excelx class
     def excelx_type(row, col, sheet = nil)

--- a/lib/roo/excelx/cell/date.rb
+++ b/lib/roo/excelx/cell/date.rb
@@ -11,7 +11,7 @@ module Roo
         def initialize(value, formula, excelx_type, style, link, base_date, coordinate)
           # NOTE: Pass all arguments to the parent class, DateTime.
           super
-          @format = excelx_type.last
+          @format = excelx_type
           @value = link ? Roo::Link.new(link, value) : create_date(base_date, value)
         end
 

--- a/lib/roo/excelx/cell/datetime.rb
+++ b/lib/roo/excelx/cell/datetime.rb
@@ -14,7 +14,7 @@ module Roo
 
         def initialize(value, formula, excelx_type, style, link, base_timestamp, coordinate)
           super(value, formula, excelx_type, style, nil, coordinate)
-          @format = excelx_type.last
+          @format = excelx_type
           @value = link ? Roo::Link.new(link, value) : create_datetime(base_timestamp, value)
         end
 

--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -12,7 +12,7 @@ module Roo
         def initialize(value, formula, excelx_type, style, link, coordinate)
           super
           # FIXME: Excelx_type is an array, but the first value isn't used.
-          @format = excelx_type.last
+          @format = excelx_type
           @value = link ? Roo::Link.new(link, value) : create_numeric(value)
         end
 

--- a/lib/roo/excelx/cell/time.rb
+++ b/lib/roo/excelx/cell/time.rb
@@ -11,7 +11,7 @@ module Roo
         def initialize(value, formula, excelx_type, style, link, base_date, coordinate)
           # NOTE: Pass all arguments to DateTime super class.
           super
-          @format = excelx_type.last
+          @format = excelx_type
           @datetime = create_datetime(base_date, value)
           @value = link ? Roo::Link.new(link, value) : (value.to_f * 86_400).to_i
         end

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -121,9 +121,6 @@ module Roo
       end
 
       def create_cell_from_value(value_type, cell, formula, format, style, hyperlink, coordinate)
-        # NOTE: format.to_s can replace excelx_type as an argument for
-        #       Cell::Time, Cell::DateTime, Cell::Date or Cell::Number, but
-        #       it will break some brittle tests.
         excelx_type = format.to_s
 
         # NOTE: There are only a few situations where value != cell.content

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -124,7 +124,7 @@ module Roo
         # NOTE: format.to_s can replace excelx_type as an argument for
         #       Cell::Time, Cell::DateTime, Cell::Date or Cell::Number, but
         #       it will break some brittle tests.
-        excelx_type = [:numeric_or_formula, format.to_s]
+        excelx_type = format.to_s
 
         # NOTE: There are only a few situations where value != cell.content
         #       1. when a sharedString is used. value = sharedString;

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -288,7 +288,7 @@ describe Roo::Excelx do
     let(:path) { 'test/files/numbers1.xlsx' }
 
     it 'returns the expected result' do
-      expect(subject.excelx_type(1, 1, "Sheet5")).to eq [:numeric_or_formula, "General"]
+      expect(subject.excelx_type(1, 1, "Sheet5")).to eq "General"
       expect(subject.excelx_type(6, 2, "Sheet5")).to eq :string
       expect(subject.excelx_type(1000, 2000, "Sheet5")).to eq nil
     end
@@ -498,7 +498,7 @@ describe Roo::Excelx do
   describe '#html_strings' do
     describe "HTML Parsing Enabling" do
       let(:path) { 'test/files/html_strings_formatting.xlsx' }
-  
+
       it 'returns the expected result' do
         expect(subject.excelx_value(1, 1, "Sheet1")).to eq("This has no formatting.")
         expect(subject.excelx_value(2, 1, "Sheet1")).to eq("<html>This has<b> bold </b>formatting.</html>")
@@ -506,7 +506,7 @@ describe Roo::Excelx do
         expect(subject.excelx_value(2, 3, "Sheet1")).to eq("<html>This has <u>underline</u> format.</html>")
         expect(subject.excelx_value(2, 4, "Sheet1")).to eq("<html>Superscript. x<sup>123</sup></html>")
         expect(subject.excelx_value(2, 5, "Sheet1")).to eq("<html>SubScript.  T<sub>j</sub></html>")
-  
+
         expect(subject.excelx_value(3, 1, "Sheet1")).to eq("<html>Bold, italics <b><i>together</i></b>.</html>")
         expect(subject.excelx_value(3, 2, "Sheet1")).to eq("<html>Bold, Underline <b><u>together</u></b>.</html>")
         expect(subject.excelx_value(3, 3, "Sheet1")).to eq("<html>Bold, Superscript. <b>x</b><sup><b>N</b></sup></html>")
@@ -575,7 +575,7 @@ describe 'Roo::Excelx with options set' do
   describe '#html_strings' do
     describe "HTML Parsing Disabled" do
       let(:path) { 'test/files/html_strings_formatting.xlsx' }
-  
+
       it 'returns the expected result' do
         expect(subject.excelx_value(1, 1, "Sheet1")).to eq("This has no formatting.")
         expect(subject.excelx_value(2, 1, "Sheet1")).to eq("This has bold formatting.")
@@ -583,7 +583,7 @@ describe 'Roo::Excelx with options set' do
         expect(subject.excelx_value(2, 3, "Sheet1")).to eq("This has underline format.")
         expect(subject.excelx_value(2, 4, "Sheet1")).to eq("Superscript. x123")
         expect(subject.excelx_value(2, 5, "Sheet1")).to eq("SubScript.  Tj")
-  
+
         expect(subject.excelx_value(3, 1, "Sheet1")).to eq("Bold, italics together.")
         expect(subject.excelx_value(3, 2, "Sheet1")).to eq("Bold, Underline together.")
         expect(subject.excelx_value(3, 3, "Sheet1")).to eq("Bold, Superscript. xN")

--- a/test/excelx/cell/test_attr_reader_default.rb
+++ b/test/excelx/cell/test_attr_reader_default.rb
@@ -44,9 +44,9 @@ class TestAttrReaderDefault < Minitest::Test
   def test_cell_default_values
     assert_values base.new(nil, nil, [], 1, nil, nil), default_type: :base, :@default_type => nil, style: 1, :@style => nil
     assert_values boolean.new("1", nil, nil, nil, nil), default_type: :boolean, :@default_type => nil, cell_type: :boolean, :@cell_type => nil
-    assert_values class_date.new("41791", nil, [:numeric_or_formula, "mm-dd-yy"], 6, nil, base_date, nil), default_type: :date, :@default_type => nil
-    assert_values class_time.new("0.521", nil, [:numeric_or_formula, "hh:mm"], 6, nil, base_timestamp, nil), default_type: :time, :@default_type => nil
-    assert_values datetime.new("41791.521", nil, [:numeric_or_formula, "mm-dd-yy hh:mm"], 6, nil, base_timestamp, nil), default_type: :datetime, :@default_type => nil
+    assert_values class_date.new("41791", nil, "mm-dd-yy", 6, nil, base_date, nil), default_type: :date, :@default_type => nil
+    assert_values class_time.new("0.521", nil, "hh:mm", 6, nil, base_timestamp, nil), default_type: :time, :@default_type => nil
+    assert_values datetime.new("41791.521", nil, "mm-dd-yy hh:mm", 6, nil, base_timestamp, nil), default_type: :datetime, :@default_type => nil
     assert_values empty.new(nil), default_type: nil, :@default_type => nil, style: nil, :@style => nil
     assert_values number.new("42", nil, ["0"], nil, nil, nil), default_type: :float, :@default_type => nil
     assert_values string.new("1", nil, nil, nil, nil), default_type: :string, :@default_type => nil, cell_type: :string, :@cell_type => nil

--- a/test/excelx/cell/test_date.rb
+++ b/test/excelx/cell/test_date.rb
@@ -14,25 +14,25 @@ class TestRooExcelxCellDate < Minitest::Test
   end
 
   def test_handles_1904_base_date
-    cell = date_cell.new('41791', nil, [:numeric_or_formula, 'mm-dd-yy'], 6, nil, base_date_1904, nil)
+    cell = date_cell.new('41791', nil, 'mm-dd-yy', 6, nil, base_date_1904, nil)
     assert_equal ::Date.new(2018, 06, 02), cell.value
   end
 
   def test_formatted_value
-    cell = date_cell.new('41791', nil, [:numeric_or_formula, 'mm-dd-yy'], 6, nil, base_date, nil)
+    cell = date_cell.new('41791', nil, 'mm-dd-yy', 6, nil, base_date, nil)
     assert_equal '06-01-14', cell.formatted_value
 
-    cell = date_cell.new('41791', nil, [:numeric_or_formula, 'yyyy-mm-dd'], 6, nil, base_date, nil)
+    cell = date_cell.new('41791', nil, 'yyyy-mm-dd', 6, nil, base_date, nil)
     assert_equal '2014-06-01', cell.formatted_value
   end
 
   def test_value_is_date
-    cell = date_cell.new('41791', nil, [:numeric_or_formula, 'mm-dd-yy'], 6, nil, base_date, nil)
+    cell = date_cell.new('41791', nil, 'mm-dd-yy', 6, nil, base_date, nil)
     assert_kind_of ::Date, cell.value
   end
 
   def test_value
-    cell = date_cell.new('41791', nil, [:numeric_or_formula, 'mm-dd-yy'], 6, nil, base_date, nil)
+    cell = date_cell.new('41791', nil, 'mm-dd-yy', 6, nil, base_date, nil)
     assert_equal ::Date.new(2014, 06, 01), cell.value
   end
 end

--- a/test/excelx/cell/test_datetime.rb
+++ b/test/excelx/cell/test_datetime.rb
@@ -19,7 +19,7 @@ class TestRooExcelxCellDateTime < Minitest::Test
       ['mmm-yy', 'JAN-15'],
       ['m/d/yy h:mm', '1/25/15 8:15']
     ].each do |format, formatted_value|
-      cell = datetime.new '42029.34375', nil, [format], nil, nil, base_timestamp, nil
+      cell = datetime.new '42029.34375', nil, format, nil, nil, base_timestamp, nil
       assert_equal formatted_value, cell.formatted_value
     end
   end
@@ -30,7 +30,7 @@ class TestRooExcelxCellDateTime < Minitest::Test
       ['h:mm:ss000 mm/yy', '8:15:00000 01/15'],
       ['mmm yyy', '2015-01-25 08:15:00']
     ].each do |format, formatted_value|
-      cell = datetime.new '42029.34375', nil, [format], nil, nil, base_timestamp, nil
+      cell = datetime.new '42029.34375', nil, format, nil, nil, base_timestamp, nil
       assert_equal formatted_value, cell.formatted_value
     end
   end

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -6,32 +6,32 @@ class TestRooExcelxCellNumber < Minitest::Test
   end
 
   def test_float
-    cell = Roo::Excelx::Cell::Number.new '42.1', nil, ['General'], nil, nil, nil
+    cell = Roo::Excelx::Cell::Number.new '42.1', nil, 'General', nil, nil, nil
     assert_kind_of(Float, cell.value)
   end
 
   def test_integer
-    cell = Roo::Excelx::Cell::Number.new '42', nil, ['0'], nil, nil, nil
+    cell = Roo::Excelx::Cell::Number.new '42', nil, '0', nil, nil, nil
     assert_kind_of(Integer, cell.value)
   end
 
   def test_scientific_notation
-    cell = Roo::Excelx::Cell::Number.new '1.2E-3', nil, ['0'], nil, nil, nil
+    cell = Roo::Excelx::Cell::Number.new '1.2E-3', nil, '0', nil, nil, nil
     assert_kind_of(Float, cell.value)
   end
 
   def test_simple_scientific_notation
-    cell = Roo::Excelx::Cell::Number.new '1E-3', nil, ['0'], nil, nil, nil
+    cell = Roo::Excelx::Cell::Number.new '1E-3', nil, '0', nil, nil, nil
     assert_kind_of(Float, cell.value)
   end
 
   def test_very_simple_scientific_notation
-    cell = Roo::Excelx::Cell::Number.new '1e6', nil, ['0'], nil, nil, nil
+    cell = Roo::Excelx::Cell::Number.new '1e6', nil, '0', nil, nil, nil
     assert_kind_of(Float, cell.value)
   end
 
   def test_percent
-    cell = Roo::Excelx::Cell::Number.new '42.1', nil, ['0.00%'], nil, nil, nil
+    cell = Roo::Excelx::Cell::Number.new '42.1', nil, '0.00%', nil, nil, nil
     assert_kind_of(Float, cell.value)
   end
 
@@ -42,14 +42,14 @@ class TestRooExcelxCellNumber < Minitest::Test
       ['#,##0.00;(#,##0.00)', '(1,042.00)'],
       ['#,##0.00;[Red](#,##0.00)', '[Red](1,042.00)']
     ].each do |style_format, result|
-      cell = Roo::Excelx::Cell::Number.new '-1042', nil, [style_format], nil, nil, nil
+      cell = Roo::Excelx::Cell::Number.new '-1042', nil, style_format, nil, nil, nil
       assert_equal result, cell.formatted_value, "Style=#{style_format}"
     end
   end
 
   def test_numbers_with_cell_errors
     Roo::Excelx::ERROR_VALUES.each do |error|
-      cell = Roo::Excelx::Cell::Number.new error, nil, ['General'], nil, nil, nil
+      cell = Roo::Excelx::Cell::Number.new error, nil, 'General', nil, nil, nil
       assert_equal error, cell.value
       assert_equal error, cell.formatted_value
     end
@@ -76,7 +76,7 @@ class TestRooExcelxCellNumber < Minitest::Test
       ['##0.0E+0', '1.0E+03'],
       ['@', '1042']
     ].each do |style_format, result|
-      cell = Roo::Excelx::Cell::Number.new '1042', nil, [style_format], nil, nil, nil
+      cell = Roo::Excelx::Cell::Number.new '1042', nil, style_format, nil, nil, nil
       assert_equal result, cell.formatted_value, "Style=#{style_format}"
     end
   end

--- a/test/excelx/cell/test_time.rb
+++ b/test/excelx/cell/test_time.rb
@@ -18,13 +18,13 @@ class TestRooExcelxCellTime < Minitest::Test
       ['[h]:mm:ss', '[1]:48:09'],
       ['mmss.0', '4809.0'] # Cell::Time always get rounded to the nearest second.
     ].each do |style_format, result|
-      cell = roo_time.new(value, nil, [:numeric_or_formula, style_format], 6, nil, base_timestamp, nil)
+      cell = roo_time.new(value, nil, style_format, 6, nil, base_timestamp, nil)
       assert_equal result, cell.formatted_value, "Style=#{style_format} is not properly formatted"
     end
   end
 
   def test_value
-    cell = roo_time.new('0.0751', nil, [:numeric_or_formula, 'h:mm'], 6, nil, base_timestamp, nil)
+    cell = roo_time.new('0.0751', nil, 'h:mm', 6, nil, base_timestamp, nil)
     assert_kind_of Integer, cell.value
   end
 end

--- a/test/roo/test_excelx.rb
+++ b/test/roo/test_excelx.rb
@@ -219,7 +219,7 @@ class TestRworkbookExcelx < Minitest::Test
       assert_equal "Bericht aus dem Sekretariat", workbook.cell(13, 1)
       assert_equal "1981-4", workbook.cell(13, "D")
       assert_equal String, workbook.excelx_type(13, "E")[1].class
-      assert_equal [:numeric_or_formula, "General"], workbook.excelx_type(13, "E")
+      assert_equal "General", workbook.excelx_type(13, "E")
       assert_equal "428", workbook.excelx_value(13, "E")
       assert_equal 428.0, workbook.cell(13, "E")
     end

--- a/test/roo/test_excelx.rb
+++ b/test/roo/test_excelx.rb
@@ -243,11 +243,11 @@ class TestRworkbookExcelx < Minitest::Test
 
   def test_simple2_excelx
     with_each_spreadsheet(name: "simple_spreadsheet", format: :excelx) do |workbook|
-      assert_equal [:numeric_or_formula, "yyyy\\-mm\\-dd"], workbook.excelx_type("A", 4)
-      assert_equal [:numeric_or_formula, "#,##0.00"], workbook.excelx_type("B", 4)
-      assert_equal [:numeric_or_formula, "#,##0.00"], workbook.excelx_type("c", 4)
-      assert_equal [:numeric_or_formula, "General"], workbook.excelx_type("d", 4)
-      assert_equal [:numeric_or_formula, "General"], workbook.excelx_type("e", 4)
+      assert_equal "yyyy\\-mm\\-dd", workbook.excelx_type("A", 4)
+      assert_equal "#,##0.00", workbook.excelx_type("B", 4)
+      assert_equal "#,##0.00", workbook.excelx_type("c", 4)
+      assert_equal "General", workbook.excelx_type("d", 4)
+      assert_equal "General", workbook.excelx_type("e", 4)
       assert_equal :string, workbook.excelx_type("f", 4)
 
       assert_equal "39209", workbook.excelx_value("a", 4)


### PR DESCRIPTION
### Summary
This PR removes the array allocation for excelx_type in create_cell_from_value. Based on the comments from https://github.com/roo-rb/roo/pull/436#issuecomment-429220926.

Instead of memoizing the arrays as suggested in the comment, I went ahead and updated the interface to not require passing an array in the first place. It looks like all of the code in this gem just discarded the array and took the last element. Let me know if you think it's worthwhile for backwards compatibility in the cell constructors that called `.last` are worth updating with some logic like:
`@format = excelx_type.is_a?(Array) ? excelx_type.last : excelx_type`.

Memory profiling against the file `test/files/Bibelbund.xlsx`

```
Master
Total allocated: 40143162 bytes (497194 objects)
Total retained:  1296083 bytes (11650 objects)

allocated memory by gem
-----------------------------------
  18683065  roo-rb-roo/lib
  11231729  nokogiri-1.8.5
  10226503  rubyzip-1.2.2
      1433  tmpdir
       240  weakref
       192  other

This PR
Total allocated: 39063762 bytes (470209 objects)
Total retained:  1295107 bytes (11631 objects)

allocated memory by gem
-----------------------------------
  17603665  will89-roo/lib
  11231729  nokogiri-1.8.5
  10226503  rubyzip-1.2.2
      1433  tmpdir
       240  weakref
       192  other
```

This PR used about ~6% less memory in the roo gem when iterating through the file.

```
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  #gem "roo", path: "/Users/gturner/development/roo"
  gem "roo", path: '/Users/will/repos/will89-roo'
  #gem "roo", path: '/Users/will/repos/roo-rb-roo'
  gem "minitest"
  gem "memory_profiler"
end

require "roo"
require "minitest/autorun"
require "memory_profiler"

class BugTest < Minitest::Test
  def test_stuff
    # add your test here
    report = MemoryProfiler.report do
      sheet = Roo::Spreadsheet.open("/Users/will/repos/will89-roo/test/files/Bibelbund.xlsx", no_hyperlinks: true)
      sheet.each_row_streaming do |row|
        row[1]
      end
    end
    report.pretty_print
  end
end
```