### PR TITLE
Fix "instance variable not initialized" warning

### DIFF
--- a/lib/roo/excelx/cell/base.rb
+++ b/lib/roo/excelx/cell/base.rb
@@ -58,7 +58,7 @@ module Roo
         end
 
         def formula?
-          !!@formula
+          !!(defined?(@formula) && @formula)
         end
 
         def link?

--- a/lib/roo/helpers/weak_instance_cache.rb
+++ b/lib/roo/helpers/weak_instance_cache.rb
@@ -10,7 +10,7 @@ module Roo
       def instance_cache(key)
         object = nil
 
-        if (ref = instance_variable_get(key)) && ref.weakref_alive?
+        if instance_variable_defined?(key) && (ref = instance_variable_get(key)) && ref.weakref_alive?
           begin
             object = ref.__getobj__
           rescue => e

--- a/test/excelx/cell/test_attr_reader_default.rb
+++ b/test/excelx/cell/test_attr_reader_default.rb
@@ -57,7 +57,7 @@ class TestAttrReaderDefault < Minitest::Test
   def assert_values(object, value_hash)
     value_hash.each do |attr_name, expected_value|
       value = if attr_name.to_s.include?("@")
-                object.instance_variable_get(attr_name)
+                object.instance_variable_defined?(attr_name) ? object.instance_variable_get(attr_name) : nil
               else
                 object.public_send(attr_name)
       end


### PR DESCRIPTION
Currently, if you run the following command it will o/p a lot of warning:
```
RUBYOPT=-v bundle exec rake
```
