### PR TITLE
Bundler version 2.0 dropped support for old ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ matrix:
   include:
     - rvm: 2.0
       gemfile: Gemfile_ruby2
+      before_install:
+        - gem install bundler -v '< 2'
     - rvm: 2.1
       gemfile: Gemfile_ruby2
+      before_install:
+        - gem install bundler -v '< 2'
     - rvm: 2.6
       env: RUBYOPT=--jit LONG_RUN=true
     - rvm: ruby-head


### PR DESCRIPTION
Related articles:

https://bundler.io/blog/2019/01/03/announcing-bundler-2.html

https://docs.travis-ci.com/user/languages/ruby/#bundler-20
