### PR TITLE
Refactor: Avoid Hash[] pattern

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -66,10 +66,10 @@ module Roo
         end
       end.compact
       @sheets = []
-      @sheets_by_name = Hash[@sheet_names.map.with_index do |sheet_name, n|
-        @sheets[n] = Sheet.new(sheet_name, @shared, n, sheet_options)
-        [sheet_name, @sheets[n]]
-      end]
+      @sheets_by_name = {}
+      @sheet_names.each_with_index do |sheet_name, n|
+        @sheets_by_name[sheet_name] = @sheets[n] = Sheet.new(sheet_name, @shared, n, sheet_options)
+      end
 
       if cell_max
         cell_count = ::Roo::Utils.num_cells_in_range(sheet_for(options.delete(:sheet)).dimensions)

--- a/lib/roo/excelx/comments.rb
+++ b/lib/roo/excelx/comments.rb
@@ -12,10 +12,10 @@ module Roo
       def extract_comments
         return {} unless doc_exists?
 
-        Hash[doc.xpath('//comments/commentList/comment').map do |comment|
+        doc.xpath('//comments/commentList/comment').each_with_object({}) do |comment, hash|
           value = (comment.at_xpath('./text/r/t') || comment.at_xpath('./text/t')).text
-          [::Roo::Utils.ref_to_key(comment.attributes['ref'].to_s), value]
-        end]
+          hash[::Roo::Utils.ref_to_key(comment.attributes['ref'].to_s)] = value
+        end
       end
     end
   end

--- a/lib/roo/excelx/images.rb
+++ b/lib/roo/excelx/images.rb
@@ -17,9 +17,9 @@ module Roo
       def extract_images_names
         return {} unless doc_exists?
 
-        Hash[doc.xpath('/Relationships/Relationship').map do |rel|
-          [rel['Id'], "roo" + rel['Target'].gsub(/\.\.\/|\//, '_')]
-        end]
+        doc.xpath('/Relationships/Relationship').each_with_object({}) do |rel, hash|
+          hash[rel['Id']] = "roo" + rel['Target'].gsub(/\.\.\/|\//, '_')
+        end
       end
     end
   end

--- a/lib/roo/excelx/relationships.rb
+++ b/lib/roo/excelx/relationships.rb
@@ -16,9 +16,9 @@ module Roo
       def extract_relationships
         return [] unless doc_exists?
 
-        Hash[doc.xpath('/Relationships/Relationship').map do |rel|
-          [rel.attribute('Id').text, rel]
-        end]
+        doc.xpath('/Relationships/Relationship').each_with_object({}) do |rel, hash|
+          hash[rel.attribute('Id').text] = rel
+        end
       end
     end
   end

--- a/lib/roo/excelx/shared_strings.rb
+++ b/lib/roo/excelx/shared_strings.rb
@@ -140,8 +140,8 @@ module Roo
           tmp_str << "<#{elem}>" if val
         end
         tmp_str << text
-        reverse_format = Hash[formatting.to_a.reverse]
-        reverse_format.each do |elem, val|
+
+        formatting.reverse_each do |elem, val|
           tmp_str << "</#{elem}>" if val
         end
         tmp_str

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -178,13 +178,13 @@ module Roo
       def extract_hyperlinks(relationships)
         return {} unless (hyperlinks = doc.xpath('/worksheet/hyperlinks/hyperlink'))
 
-        Hash[hyperlinks.map do |hyperlink|
-          if hyperlink['id'] && (relationship = relationships[hyperlink['id']])
+        hyperlinks.each_with_object({}) do |hyperlink, hash|
+          if relationship = relationships[hyperlink['id']]
             target_link = relationship['Target']
             target_link += "##{hyperlink['location']}" if hyperlink['location']
-            [::Roo::Utils.ref_to_key(hyperlink['ref']), target_link]
+            hash[::Roo::Utils.ref_to_key(hyperlink.attributes["ref"].to_s)] = target_link
           end
-        end.compact]
+        end
       end
 
       def expand_merged_ranges(cells)

--- a/lib/roo/excelx/styles.rb
+++ b/lib/roo/excelx/styles.rb
@@ -55,9 +55,9 @@ module Roo
       end
 
       def extract_num_fmts
-        Hash[doc.xpath('//numFmt').map do |num_fmt|
-          [num_fmt['numFmtId'], num_fmt['formatCode']]
-        end]
+        doc.xpath('//numFmt').each_with_object({}) do |num_fmt, hash|
+          hash[num_fmt['numFmtId']] = num_fmt['formatCode']
+        end
       end
     end
   end

--- a/lib/roo/excelx/workbook.rb
+++ b/lib/roo/excelx/workbook.rb
@@ -29,13 +29,13 @@ module Roo
 
       # aka labels
       def defined_names
-        Hash[doc.xpath('//definedName').map do |defined_name|
+        doc.xpath('//definedName').each_with_object({}) do |defined_name, hash|
           # "Sheet1!$C$5"
           sheet, coordinates = defined_name.text.split('!$', 2)
           col, row = coordinates.split('$')
           name = defined_name['name']
-          [name, Label.new(name, sheet, row, col)]
-        end]
+          hash[name] = Label.new(name, sheet, row, col)
+        end
       end
 
       def base_timestamp

--- a/lib/roo/open_office.rb
+++ b/lib/roo/open_office.rb
@@ -563,7 +563,7 @@ module Roo
     end
 
     def read_labels
-      @label ||= Hash[doc.xpath('//table:named-range').map do |ne|
+      @label ||= doc.xpath('//table:named-range').each_with_object({}) do |ne, hash|
         #-
         # $Sheet1.$C$5
         #+
@@ -571,8 +571,8 @@ module Roo
         sheetname, coords = attribute(ne, 'cell-range-address').to_s.split('.$')
         col, row          = coords.split('$')
         sheetname         = sheetname[1..-1] if sheetname[0, 1] == '$'
-        [name, [sheetname, row, col]]
-      end]
+        hash[name] = [sheetname, row, col]
+      end
     end
 
     def read_styles(style_elements)


### PR DESCRIPTION
Hash[] pattern creates many unnecessary intermediate arrays.
