### PR TITLE
Skip extract_hyperlinks if not required

### DIFF
--- a/lib/roo/excelx/relationships.rb
+++ b/lib/roo/excelx/relationships.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'roo/excelx/extractor'
 
 module Roo
@@ -9,6 +11,12 @@ module Roo
 
       def to_a
         @relationships ||= extract_relationships
+      end
+
+      def include_type?(type)
+        to_a.any? do |_, rel|
+          rel["Type"]&.include? type
+        end
       end
 
       private

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -22,7 +22,7 @@ module Roo
 
       def hyperlinks(relationships)
         # If you're sure you're not going to need this hyperlinks you can discard it
-        @hyperlinks ||= if @options[:no_hyperlinks]
+        @hyperlinks ||= if @options[:no_hyperlinks] || !relationships.include_type?("hyperlink")
           {}
         else
           extract_hyperlinks(relationships)

--- a/spec/lib/roo/excelx/relationships_spec.rb
+++ b/spec/lib/roo/excelx/relationships_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Roo::Excelx::Relationships do
+  subject(:relationships) { Roo::Excelx::Relationships.new Roo::Excelx.new(path).rels_files[0] }
+
+  describe "#include_type?" do
+    [
+      ["with hyperlink type", "test/files/link.xlsx", true, false],
+      ["with nil path", "test/files/Bibelbund.xlsx", false, false],
+      ["with comments type", "test/files/comments-google.xlsx", false, true],
+    ].each do |context_desc, file_path, hyperlink_value, comments_value|
+      context context_desc do
+        let(:path) { file_path }
+
+        it "should return #{hyperlink_value} for hyperlink" do
+          expect(subject.include_type?("hyperlink")).to be hyperlink_value
+        end
+
+        it "should return #{hyperlink_value} for link" do
+          expect(subject.include_type?("link")).to be hyperlink_value
+        end
+
+        it "should return false for hypelink" do
+          expect(subject.include_type?("hypelink")).to be false
+        end
+
+        it "should return false for coment" do
+          expect(subject.include_type?("coment")).to be false
+        end
+
+        it "should return #{comments_value} for comments" do
+          expect(subject.include_type?("comments")).to be comments_value
+        end
+
+        it "should return #{comments_value} for comment" do
+          expect(subject.include_type?("comment")).to be comments_value
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Revisiting https://github.com/roo-rb/roo/pull/436 

This Patch uses relationships data to determine if a sheet includes hyperlink or not.

As extract_hyperlinks loads the whole document in memory it is quite problematic for each_row_streaming. This patch tries to skip extract_hyperlinks when not required.

