### PR TITLE
Add rounding for date parser

### DIFF
--- a/lib/roo/excelx/cell/date.rb
+++ b/lib/roo/excelx/cell/date.rb
@@ -20,7 +20,7 @@ module Roo
         def create_datetime(_,_);  end
 
         def create_date(base_date, value)
-          base_date + value.to_i
+          base_date + value.to_f.round(6)
         end
       end
     end


### PR DESCRIPTION
To avoid float precision mistake, e.g. 42988.99999999999 (11 September 2017) should be parsed same as 42989.0 to match with date time parser and excel behaviour

Fixes https://github.com/roo-rb/roo/issues/500