### PR TITLE
Update rubyzip from 1.2.1 to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ##  Unreleased
+### Changed / Added
+- Updated rubyzip version. Now minimal version is 1.3.0. [CVE-2019-16892](https://github.com/rubyzip/rubyzip/pull/403)
 
 ##  [2.8.2] 2019-02-01
 ### Changed/Added

--- a/roo.gemspec
+++ b/roo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version  = ">= 2.3.0"
 
   spec.add_dependency 'nokogiri', '~> 1'
-  spec.add_dependency 'rubyzip', '>= 1.2.1', '< 2.0.0'
+  spec.add_dependency 'rubyzip', '>= 1.3.0', '< 2.0.0'
 
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'

--- a/roo.gemspec
+++ b/roo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version  = ">= 2.3.0"
 
   spec.add_dependency 'nokogiri', '~> 1'
-  spec.add_dependency 'rubyzip', '>= 1.3.0', '< 2.0.0'
+  spec.add_dependency 'rubyzip', '>= 1.3.0', '< 3.0.0'
 
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'


### PR DESCRIPTION
### Summary

Updated rubyzip version. Now minimal version is 1.3.0. [CVE-2019-16892](https://github.com/rubyzip/rubyzip/pull/403)