### PR TITLE
Style xml file not present with xlsx file

### DIFF
--- a/lib/roo/excelx/shared.rb
+++ b/lib/roo/excelx/shared.rb
@@ -16,6 +16,12 @@ module Roo
       end
 
       def styles
+        begin
+          file_path = File.join(@dir, 'roo_styles.xml')
+          File.open(file_path)
+        rescue
+          File.open(file_path, "w")
+        end
         @styles ||= Styles.new(File.join(@dir, 'roo_styles.xml'))
       end
 

--- a/lib/roo/excelx/shared.rb
+++ b/lib/roo/excelx/shared.rb
@@ -16,13 +16,9 @@ module Roo
       end
 
       def styles
-        begin
-          file_path = File.join(@dir, 'roo_styles.xml')
-          File.open(file_path)
-        rescue
-          File.open(file_path, "w")
-        end
-        @styles ||= Styles.new(File.join(@dir, 'roo_styles.xml'))
+        file_path = File.join(@dir, 'roo_styles.xml')
+        File.new(file_path, "a+") {} unless File.exists?(file_path)
+        @styles ||= Styles.new(file_path)
       end
 
       def shared_strings


### PR DESCRIPTION
There is issue when a xlsx file does not contain style xml compressed with it,
we should create a blank style xml file so that it does not raise issue and stop processing xlsx file , only if the style xml is not present?
The below file was created with js library https://github.com/egeriis/zipcelx/wiki/How-to-use
[Main View_7oct14.xlsx](https://github.com/roo-rb/roo/files/3844981/Main.View_7oct14.xlsx)

There can be other ways to solve this issue more efficiently but for me currently solved by making below changes