### PR TITLE
Fix some ruby 2.7 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ##  Unreleased
 
+[2.8.4] 2020-08-18
+### Resolved
+- Ruby 2.7 deprecation warnings for "Using the last argument as keyword parameters is deprecated".
+
 ##  [2.8.3] 2020-02-03
 ### Changed/Added
 - Updated rubyzip version. Now minimal version is 1.3.0 [515](https://github.com/roo-rb/roo/pull/515) - [CVE-2019-16892](https://github.com/rubyzip/rubyzip/pull/403)

--- a/lib/roo/csv.rb
+++ b/lib/roo/csv.rb
@@ -89,16 +89,16 @@ module Roo
 
     def each_row(options, &block)
       if uri?(filename)
-        each_row_using_tempdir(options, &block)
+        each_row_using_tempdir(**options, &block)
       else
-        csv_foreach(filename_or_stream, options, &block)
+        csv_foreach(filename_or_stream, **options, &block)
       end
     end
 
     def each_row_using_tempdir(options, &block)
       ::Dir.mktmpdir(Roo::TEMP_PREFIX, ENV["ROO_TMP"]) do |tmpdir|
         tmp_filename = download_uri(filename, tmpdir)
-        csv_foreach(tmp_filename, options, &block)
+        csv_foreach(tmp_filename, **options, &block)
       end
     end
 

--- a/lib/roo/version.rb
+++ b/lib/roo/version.rb
@@ -1,3 +1,3 @@
 module Roo
-  VERSION = "2.8.3"
+  VERSION = "2.8.4"
 end


### PR DESCRIPTION
### Summary

Currently the following deprecation warning is produced when using ruby 2.7:

    ~/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/roo-2.8.3/lib/roo/csv.rb:96:
    warning: Using the last argument as keyword parameters is
    deprecated; maybe ** should be added to the call
    ~/.rbenv/versions/2.7.1/lib/ruby/2.7.0/csv.rb:508: warning: The
    called method `foreach' is defined here

The following code (in master) addresses the deprecation:

https://github.com/roo-rb/roo/blob/573d02e3997df9c6a03fafc03125635819c1a769/lib/roo/csv.rb#L105-L111

This PR applies the same change to other methods. 