### PR TITLE
Handle empty v element in column xml

### DIFF
--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -44,6 +44,8 @@ module Roo
       # Yield each cell as Excelx::Cell to caller for given
       # row xml
       def each_cell(row_xml)
+        return to_enum(:each_cell, row_xml) unless block_given?
+
         return [] unless row_xml
         row_xml.children.each do |cell_element|
           coordinate = ::Roo::Utils.extract_coordinate(cell_element["r"])
@@ -111,7 +113,7 @@ module Roo
             format = style_format(style)
             value_type = cell_value_type(cell_xml["t"], format)
 
-            return create_cell_from_value(value_type, cell, formula, format, style, hyperlink, coordinate)
+            return create_cell_from_value(value_type, cell, formula, format, style, hyperlink, coordinate) unless cell.content.empty?
           end
         end
 

--- a/spec/lib/roo/excelx/sheet_doc_spec.rb
+++ b/spec/lib/roo/excelx/sheet_doc_spec.rb
@@ -8,4 +8,27 @@ describe Roo::Excelx::SheetDoc do
   example "#last_row" do
     expect(subject.last_row).to eq 3
   end
+
+  describe "#each_cell" do
+    let(:relationships) { instance_double(Roo::Excelx::Relationships, include_type?: false) }
+    let(:styles) { instance_double(Roo::Excelx::Styles, style_format: 'General') }
+    let(:shared) { instance_double(Roo::Excelx::Shared, styles: styles) }
+    let(:sheet_doc) { described_class.new(nil, relationships, shared) }
+
+    context "empty v element" do
+      let(:row_xml) { Nokogiri.parse('<row r="1"><c r="A1"><v/></c></row>').root }
+
+      it "returns an empty cell" do
+        expect(sheet_doc.each_cell(row_xml)).to all(be_a(Roo::Excelx::Cell::Empty))
+      end
+    end
+
+    context "no v element" do
+      let(:row_xml) { Nokogiri.parse('<row r="1"><c r="A1"></c></row>').root }
+
+      it "returns an empty cell" do
+        expect(sheet_doc.each_cell(row_xml)).to all(be_a(Roo::Excelx::Cell::Empty))
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Summary

This is an attempt to fix https://github.com/roo-rb/roo/issues/541.

### Other Information

I'm open to suggestions on how the test is structured. I wanted to setup the tests in a way that made it easier to write future tests against various cell xml configurations. I use this gem at work with customer data so generating spreadsheets that reproduce issues is difficult due to having to scrub the data. I can easily unzip the spreadsheets to identify 'interesting' xml tags.

Ideally, I would have tested `cell_from_xml` to avoid dealing with arrays but I didn't want to change the visibility of that method for this bug fix.

I would be interested in trying to restructure the SheetDoc class so it's easier to test some of core functionality of methods like `cell_from_xml` and `create_cell_from_value`. Is that something that would be of interest?

