### PR TITLE
fix: info will break if e.g. Roo::CSV is initialized by stream object

### DIFF
--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -201,7 +201,7 @@ class Roo::Base
   # this document.
   def info
     without_changing_default_sheet do
-      result = "File: #{File.basename(@filename)}\n"\
+      result = is_stream?(@filename) ? "Content: stream\n" : "File: #{File.basename(@filename)}\n"\
         "Number of sheets: #{sheets.size}\n"\
         "Sheets: #{sheets.join(', ')}\n"
       n = 1


### PR DESCRIPTION
### Summary

This is a bug fix for method Base::info when object is initialized by stream and not filename

Testcode will break

``` ruby
require 'roo'

content = "Id,Name,Surname,Title\n"
(1..1000).each { |i| content << "#{i},John,Wick,Actor\n" }
content_io = StringIO.new(content)
spreadsheet = Roo::CSV.new(content_io)
puts spreadsheet.info
```
