### PR TITLE
Fix :formatted_value for `0%`-formatted numeric cells

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -51,7 +51,7 @@ module Roo
           when /^#,##0.(0+)$/ then number_format("%.#{$1.size}f")
           when '0%'
             proc do |number|
-              Kernel.format('%d%%', number.to_f * 100)
+              Kernel.format('%.0f%%', number.to_f * 100)
             end
           when '0.00%'
             proc do |number|

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -35,6 +35,11 @@ class TestRooExcelxCellNumber < Minitest::Test
     assert_kind_of(Float, cell.value)
   end
 
+  def test_rounded_percent_formatted_value
+    cell = Roo::Excelx::Cell::Number.new '0.569999999995', nil, ['0%'], nil, nil, nil
+    assert_equal('57%', cell.formatted_value)
+  end
+
   def test_formats_with_negative_numbers
     [
       ['#,##0 ;(#,##0)', '(1,042)'],


### PR DESCRIPTION
### Summary

Fixes #547.  Possibly related to #384?

Currently, the formatter for `0%`-formatted cells (integer percentages) uses `%d%%`, which truncates input.  This exposes floating-point errors in strange ways.  Specifically, `57%` is stored as `0.56999999999999995`, which comes out of the formatter as `56%`.  Changing the format template to a 0-precision float, `%.0f%%`, instructs the formatter to round the input instead of truncating.