### PR TITLE
Ignore all richdata at 'xl/richData' of XSLX

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -429,6 +429,11 @@ module Roo
       entries.each do |entry|
         path =
         case entry.name.downcase
+        when /richdata/
+          # FIXME: Ignore richData as parsing is not implemented yet and can cause
+          # Zip::DestinationFileExistsError when including a second "styles.xml" entry
+          # see http://schemas.microsoft.com/office/spreadsheetml/2017/richdata2
+          nil
         when /sharedstrings.xml$/
           "#{@tmpdir}/roo_sharedStrings.xml"
         when /styles.xml$/


### PR DESCRIPTION
### Summary

When richData is used at Excelx i.e. embedded image data (https://docs.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/4f3a80fd-1776-407f-8807-2497a4692dea) a second styles.xml (xl/styles.xml and xl/richData/richStyles.xml) will be mapped and result in a Zip::DestinationFileExistsError.

As richData is not implemented, we should ignore the corresponding entries.