### PR TITLE
add Ruby 3.0 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
   - jruby-9.1.6.0
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'simplecov', '>= 0.9.0', require: false
   gem 'coveralls', require: false
   gem "minitest-reporters"
+  gem 'webrick' if RUBY_VERSION >= '3.0.0'
 end
 
 group :local_development do


### PR DESCRIPTION
### Summary

This PR is to add Ruby 3.0 to CI.

### Other Information

https://github.com/roo-rb/roo/blob/030d541a87087440ad1ba8715b08d9792fd09736/Gemfile#L13
About the above change:
From Ruby 3.0, `webrick` is no longer a standard library so we need to install `webrick` manually.
see:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/