### PR TITLE
Use Dir.glob instead of git ls-files in gemspec

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage               = 'https://github.com/roo-rb/roo'
   spec.license                = 'MIT'
 
-  spec.files                  = `git ls-files -z`.split("\x0")
-  spec.files.reject! { |fn| fn.include?('test/files') }
+  spec.files                  = Dir.glob('lib/**/*').reject { |f| File.directory?(f) } + %w{CHANGELOG.md LICENSE README.md Gemfile roo.gemspec}
+
   spec.require_paths          = ['lib']
 
   spec.required_ruby_version  = ">= 2.5.0"


### PR DESCRIPTION
### Summary

Using git ls-files causes strange errors with the [inspec plugin system](https://docs.chef.io/inspec/plugins/). This is due to the inspec plugin system reading the gemspec and attempting to execute the `files` command which throws an error with the installed version of the gem. This updated gemspec will execute successfully even if git isn't installed or a .git directory is not present.

### Other Information

Without this change the following error happens if a user attempts to use an inspec plugin that requires 'roo': 

```bash
sh-4.4# inspec plugin list
Invalid gemspec in [/root/.inspec/gems/2.7.0/gems/roo-2.8.3/roo.gemspec]: No such file or directory - git
[2021-10-07T14:28:56+00:00] ERROR: Could not load plugin inspec-reporter-json-hdf: unable to find /root/.inspec/gems/2.7.0/gems/roo-2.8.3/roo.gemspec for gem roo
[2021-10-07T14:28:57+00:00] ERROR: Errors were encountered while loading plugins...
[2021-10-07T14:28:57+00:00] ERROR: Plugin name: inspec-reporter-json-hdf
[2021-10-07T14:28:57+00:00] ERROR: Error: unable to find /root/.inspec/gems/2.7.0/gems/roo-2.8.3/roo.gemspec for gem roo
[2021-10-07T14:28:57+00:00] ERROR: Run again with --debug for a stacktrace.
```

This should also have the added bonus of slimming what is actually published with the gem, since it seems likely that the test and spec files are not required for end users of roo.