### PR TITLE
Support string ios

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -391,19 +391,25 @@ module Roo
       end
     end
 
-    # Extracts all needed files from the zip file
     def process_zipfile(zipfilename_or_stream)
       @sheet_files = []
 
-      unless is_stream?(zipfilename_or_stream)
-        zip_file = Zip::File.open(zipfilename_or_stream)
+      entries = if is_stream?(zipfilename_or_stream)
+        zip_stream = Zip::InputStream.new(zipfilename_or_stream)
+        entries = []
+        while (entry = zip_stream.get_next_entry)
+          entries << entry
+        end
+
+        entries
       else
-        zip_file = Zip::CentralDirectory.new
-        zip_file.read_from_stream zipfilename_or_stream
+        zip_file = Zip::File.open(zipfilename_or_stream)
+        zip_file.to_a
       end
 
-      process_zipfile_entries zip_file.to_a.sort_by(&:name)
+      process_zipfile_entries entries.sort_by(&:name)
     end
+
 
     def process_zipfile_entries(entries)
       # NOTE: When Google or Numbers 3.1 exports to xlsx, the worksheet filenames

--- a/spec/lib/roo/excelx_spec.rb
+++ b/spec/lib/roo/excelx_spec.rb
@@ -56,6 +56,14 @@ describe Roo::Excelx do
         expect(subject).to be_a(Roo::Excelx)
       end
     end
+
+    context 'given a URI created stream' do
+      let(:file) { 'test/files/simple_spreadsheet.xlsx' }
+
+      it 'creates an instance' do
+        expect(subject).to be_a(Roo::Excelx)
+      end
+    end
   end
 
   describe '#cell' do


### PR DESCRIPTION
### Summary

Closes #360 

Uses `Zip::InputStream` to get each entry (per RubyZip's [README](https://github.com/rubyzip/rubyzip#notes-on-zipinputstream)).
