### PR TITLE
Extract embedded_image_refs_anchored_to_single_cells

### DIFF
--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -26,7 +26,7 @@ module Roo
     require 'roo/excelx/format'
     require 'roo/excelx/images'
 
-    delegate [:styles, :workbook, :shared_strings, :rels_files, :sheet_files, :comments_files, :image_rels, :image_files] => :@shared
+    delegate [:styles, :workbook, :shared_strings, :rels_files, :sheet_files, :comments_files, :image_rels, :image_files, :drawings] => :@shared
     ExceedsMaxError = Class.new(StandardError)
 
     # initialization and opening of a spreadsheet file
@@ -460,6 +460,12 @@ module Roo
           # Extracting drawing relationships to make images lists for each sheet
           nr = Regexp.last_match[1].to_i
           image_rels[nr - 1] = "#{@tmpdir}/roo_image_rels#{nr}"
+        when /drawing([0-9]+).xml$/
+          # Extracting drawings to recover images for each sheet.
+          # This is conceptually wrong (we should be following rels from sheet{n}.xml.rels),
+          # but just happens to work for common cases.
+          nr = Regexp.last_match[1].to_i
+          drawings[nr - 1] = "#{@tmpdir}/roo_drawing#{nr}.xml"
         end
 
         entry.extract(path) if path

--- a/lib/roo/excelx/shared.rb
+++ b/lib/roo/excelx/shared.rb
@@ -4,7 +4,7 @@ module Roo
     #          reduce memory usage and reduce the number of objects being passed
     #          to various inititializers.
     class Shared
-      attr_accessor :comments_files, :sheet_files, :rels_files, :image_rels, :image_files
+      attr_accessor :comments_files, :sheet_files, :rels_files, :image_rels, :image_files, :drawings
       def initialize(dir, options = {})
         @dir = dir
         @comments_files = []
@@ -13,6 +13,7 @@ module Roo
         @options = options
         @image_rels = []
         @image_files = []
+        @drawings = []
       end
 
       def styles


### PR DESCRIPTION
### Summary

Sheet#embedded_image_refs_anchored_to_single_cells returns the refs for images anchored to a single cell.