### PR TITLE
Roo::Base#each_with_pagename returns Enumerator Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ##  Unreleased
 
+### Changed/Added
+- Roo::Base#each_with_pagename returns Enumerator Object [576](https://github.com/roo-rb/roo/pull/576)
+
 ##  [2.9.0] 2022-03-19
 
 ### Changed/Added

--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -250,8 +250,10 @@ class Roo::Base
 
   # iterate through all worksheets of a document
   def each_with_pagename
-    sheets.each do |s|
-      yield sheet(s, true)
+    Enumerator.new do |yielder|
+      sheets.each do |s|
+        yielder << sheet(s, true)
+      end
     end
   end
 

--- a/spec/lib/roo/base_spec.rb
+++ b/spec/lib/roo/base_spec.rb
@@ -182,6 +182,14 @@ describe Roo::Base do
     end
   end
 
+  describe '#each_with_pagename' do
+    it 'should return an enumerator with all the rows' do
+      each_with_pagename = spreadsheet.each_with_pagename
+      expect(each_with_pagename).to be_a(Enumerator)
+      expect(each_with_pagename.to_a.last).to eq([spreadsheet.default_sheet, spreadsheet])
+    end
+  end
+
   describe '#each' do
     it 'should return an enumerator with all the rows' do
       each = spreadsheet.each


### PR DESCRIPTION
### Summary
Generally in ruby, when a method named like "each" called without block returns an Enumerator.