### PR TITLE
Adds Ruby 3.2 and JRuby 9.4 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,14 +16,16 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
           - ruby-head
           - jruby-9.3.3.0
+          - jruby-9.4
         include:
           - ruby: ruby-head
             env:
               RUBYOPT: '--jit'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ##  Unreleased
 
 ### Changed/Added
+- Add Ruby 3.2 and JRuby 9.4 to the CI matrix [582](https://github.com/roo-rb/roo/pull/582)
 
 ##  [2.10.0] 2023-02-07
 


### PR DESCRIPTION
### Summary

Adds Ruby 3.2 and JRuby 9.4 to the CI matrix.  Also updates the checkout action version.

### Other Information

Runs green on my fork.