### PR TITLE
Fix Roo::Base#each_with_pagename degraded at #576

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed/Added
 - Prevent warnings on Ruby 3.1 if finalizer is called twice [586](https://github.com/roo-rb/roo/pull/586)
+- Fix Roo::Base#each_with_pagename degraded at [576](https://github.com/roo-rb/roo/pull/576) [583](https://github.com/roo-rb/roo/pull/583)
 
 ##  [2.10.0] 2023-02-07
 

--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -250,10 +250,10 @@ class Roo::Base
 
   # iterate through all worksheets of a document
   def each_with_pagename
-    Enumerator.new do |yielder|
-      sheets.each do |s|
-        yielder << sheet(s, true)
-      end
+    return to_enum(:each_with_pagename) { sheets.size } unless block_given?
+
+    sheets.each do |s|
+      yield sheet(s, true)
     end
   end
 

--- a/spec/lib/roo/base_spec.rb
+++ b/spec/lib/roo/base_spec.rb
@@ -183,10 +183,22 @@ describe Roo::Base do
   end
 
   describe '#each_with_pagename' do
-    it 'should return an enumerator with all the rows' do
-      each_with_pagename = spreadsheet.each_with_pagename
-      expect(each_with_pagename).to be_a(Enumerator)
-      expect(each_with_pagename.to_a.last).to eq([spreadsheet.default_sheet, spreadsheet])
+    context 'when block given' do
+      it 'iterate with sheet and sheet_name' do
+        sheet_names = []
+        spreadsheet.each_with_pagename do |sheet_name, sheet|
+          sheet_names << sheet_name
+        end
+        expect(sheet_names).to eq ['my_sheet', 'blank sheet']
+      end
+    end
+
+    context 'when called without block' do
+      it 'should return an enumerator with all the rows' do
+        each_with_pagename = spreadsheet.each_with_pagename
+        expect(each_with_pagename).to be_a(Enumerator)
+        expect(each_with_pagename.to_a.last).to eq([spreadsheet.default_sheet, spreadsheet])
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

`Roo::Excel#each_with_pagename` broken at [this change](https://github.com/roo-rb/roo/pull/576).
It intended to add feature to return Enumerator if block is not given, on the other side, it should keep previous behavior.
In fact, the latter was not followed.

This PR fix the behavior when block given.