### PR TITLE
Avoid warnings in Ruby 3.1 when finalizer is called twice [fix #585]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ##  Unreleased
 
 ### Changed/Added
+- Prevent warnings on Ruby 3.1 if finalizer is called twice [586](https://github.com/roo-rb/roo/pull/586)
 
 ##  [2.10.0] 2023-02-07
 

--- a/lib/roo/tempdir.rb
+++ b/lib/roo/tempdir.rb
@@ -4,7 +4,10 @@ module Roo
       if @tempdirs && (dirs_to_remove = @tempdirs[object_id])
         @tempdirs.delete(object_id)
         dirs_to_remove.each do |dir|
-          ::FileUtils.remove_entry(dir)
+          # Pass force=true to avoid an exception (and thus warnings in Ruby 3.1) if dir has
+          # already been removed. This can occur when the finalizer is called both in a forked
+          # child process and in the parent.
+          ::FileUtils.remove_entry(dir, true)
         end
       end
     end


### PR DESCRIPTION
Fixes #585 