### PR TITLE
Refactor files to includes only the necessary

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -1,7 +1,6 @@
-# encoding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'roo/version'
+# frozen_string_literal: true
+
+require_relative 'lib/roo/version'
 
 Gem::Specification.new do |spec|
   spec.name                   = 'roo'
@@ -13,14 +12,13 @@ Gem::Specification.new do |spec|
   spec.homepage               = 'https://github.com/roo-rb/roo'
   spec.license                = 'MIT'
 
-  spec.files                  = `git ls-files -z`.split("\x0")
-  spec.files.reject! { |fn| fn.include?('test/files') }
+  spec.files                  = Dir['lib/**/*', '*.md', 'LICENSE', 'roo.gemspec', 'examples/**/*']
   spec.require_paths          = ['lib']
 
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
-    spec.required_ruby_version  = ">= 2.6.0"
+    spec.required_ruby_version  = '>= 2.6.0'
   else
-    spec.required_ruby_version  = ">= 2.7.0"
+    spec.required_ruby_version  = '>= 2.7.0'
   end
 
   spec.add_dependency 'nokogiri', '~> 1'


### PR DESCRIPTION
### Summary

Hi, after installing the gem, I've noticed that some unnecessary folders and file are included. Yet, Bundler's [current template](https://github.com/rubygems/rubygems/blob/812366203b3fd9bb4e278db790c23f35f947c733/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L30-L35) is using `git ls-files` but its not excluding `.github` for instance.

With this PR, it would include only the necessary.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Roo!