### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/roo

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |spec|
   if RUBY_VERSION >= '3.0.0'
     spec.add_development_dependency 'matrix'
   end
+
+  spec.metadata["changelog_uri"] = spec.homepage + '/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/roo which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/
