### PR TITLE
Fix negative numeric formatting

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -86,7 +86,7 @@ module Roo
         def number_format(formatter, negative_formatter = nil)
           proc do |number|
             if negative_formatter
-              formatter = number.to_i > 0 ? formatter : negative_formatter
+              formatter = negative_formatter if number.to_f.negative?
               number = number.to_f.abs
             end
 

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -52,6 +52,18 @@ class TestRooExcelxCellNumber < Minitest::Test
     end
   end
 
+  def test_formats_with_zeros
+    [
+      ['#,##0 ;(#,##0)', '0'],
+      ['#,##0 ;[Red](#,##0)', '0'],
+      ['#,##0.00;(#,##0.00)', '0.00'],
+      ['#,##0.00;[Red](#,##0.00)', '0.00']
+    ].each do |style_format, result|
+      cell = Roo::Excelx::Cell::Number.new '0', nil, [style_format], nil, nil, nil
+      assert_equal result, cell.formatted_value, "Style=#{style_format}"
+    end
+  end
+
   def test_numbers_with_cell_errors
     Roo::Excelx::ERROR_VALUES.each do |error|
       cell = Roo::Excelx::Cell::Number.new error, nil, ['General'], nil, nil, nil


### PR DESCRIPTION
### Summary

The numeric formatting of `0` should use the formatting of positive numbers, not negative. Fix the `number_format` method to check for negative numbers when using the negative formatter.