### PR TITLE
Add csv to gemspec

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
     spec.required_ruby_version  = ">= 2.7.0"
   end
 
+  spec.add_dependency 'csv', '~> 3'
   spec.add_dependency 'nokogiri', '~> 1'
   spec.add_dependency 'rubyzip', '>= 1.3.0', '< 3.0.0'
 


### PR DESCRIPTION
### Summary

This addresses the following warning:
warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of roo-2.10.1 to add csv into its gemspec.

Closes #604