### PR TITLE
Patch for invalid value for Integer(): ""

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -17,7 +17,7 @@ module Roo
         end
 
         def create_numeric(number)
-          return number if Excelx::ERROR_VALUES.include?(number)
+          return number if Excelx::ERROR_VALUES.include?(number) || number == ''
           case @format
           when /%/
             Float(number)


### PR DESCRIPTION
When xlsx file has a column of type number but for some reason the cell value is an empty string, line 27 is raising ArgumentError invalid value for Integer(): ""

This is a temporary patch to handle situations where we cannot access/change excel files manually,

#574