### PR TITLE
Explicitly require Base64 and CSV

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,8 +18,9 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - ruby-head
-          - jruby-9.3.3.0
+          - jruby-9.4.10.0
         include:
           - ruby: ruby-head
             env:
@@ -33,4 +34,3 @@ jobs:
       - run: bundle exec rake
         env:
           LONG_RUN: true
-

--- a/roo.gemspec
+++ b/roo.gemspec
@@ -23,6 +23,10 @@ Gem::Specification.new do |spec|
     spec.required_ruby_version  = ">= 2.7.0"
   end
 
+  if RUBY_VERSION >= '3.4.0'
+    spec.add_dependency 'base64', '~> 0.2'
+    spec.add_dependency 'csv', '~> 3'
+  end
   spec.add_dependency 'nokogiri', '~> 1'
   spec.add_dependency 'rubyzip', '>= 1.3.0', '< 3.0.0'
 


### PR DESCRIPTION
### Summary

Ruby has been trying to reduce the surface area of the standard library. While Base64 and CSV are default gems, starting with Ruby 3.4, they are no longer included in the standard library and must be explicitly included as dependencies

## Other information

Resolves #604 