### PR TITLE
Fix URI::RFC3986_Parser deprecation warnings

### DIFF
--- a/lib/roo/spreadsheet.rb
+++ b/lib/roo/spreadsheet.rb
@@ -25,7 +25,7 @@ module Roo
           extension.tr('.', '').downcase.to_sym
         else
           parsed_path =
-            if path =~ /\A#{::URI::DEFAULT_PARSER.make_regexp}\z/
+            if path =~ /\A#{URI::RFC2396_PARSER.make_regexp}\z/
               # path is 7th match
               Regexp.last_match[7]
             else


### PR DESCRIPTION
### Summary

`URI::RFC3986_Parser.make_regexp` is deprecated and the deprecation notice directs to use `URI::RFC2396_PARSER.make_regexp` instead. While the project is using `URI::DEFAULT_PARSER`, this currently returns `URI::RFC3986_Parser`.