### PR TITLE
Explicitly require Logger

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
     spec.required_ruby_version  = ">= 2.7.0"
   end
 
+  spec.add_dependency 'logger', '~> 1'
   spec.add_dependency 'nokogiri', '~> 1'
   spec.add_dependency 'rubyzip', '>= 1.3.0', '< 3.0.0'
 


### PR DESCRIPTION
### Summary

Ruby has been trying to reduce the surface area of the standard library. From Ruby 3.5, Logger will transition from being in the standard library to being a default gem. This removes the deprecation warnings by explicitly including Logger as a dependency