### PR TITLE
Don't globally set Encoding.default_external

### DIFF
--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -4,8 +4,6 @@
 # with the wrong spreadsheet class
 #STDERR.reopen "/dev/null","w"
 
-Encoding.default_external = "UTF-8"
-
 require 'test_helper'
 require 'stringio'
 


### PR DESCRIPTION
### Summary

Using `Encoding.default_external` is a global override that can cause problems with other libraries, and Ruby now throws warnings about setting this value.

### Other Information

After removing this setting, the test suite still passes so, if this is still needed in certain circumstances, it should be set in a way that is scoped to the code that needs it