### PR TITLE
Explicitly define mutable strings

### DIFF
--- a/lib/roo/formatters/yaml.rb
+++ b/lib/roo/formatters/yaml.rb
@@ -13,7 +13,7 @@ module Roo
         from_column ||= first_column(sheet)
         to_column ||= last_column(sheet)
 
-        result = "--- \n"
+        result = String.new("--- \n")
         from_row.upto(to_row) do |row|
           from_column.upto(to_column) do |col|
             next if empty?(row, col, sheet)

--- a/test/roo/test_open_office.rb
+++ b/test/roo/test_open_office.rb
@@ -224,7 +224,7 @@ class TestRooOpenOffice < Minitest::Test
       assert workbook.empty?("C", 1)
       assert workbook.empty?("D", 1)
       expected = 1
-      letter = "e"
+      letter = String.new("e")
       while letter <= "u"
         assert_equal expected, workbook.cell(letter, 1)
         letter.succ!


### PR DESCRIPTION
### Summary

Use `String.new` to explicitly define strings that will be mutable

### Other Information

Ruby 2.3 introduced a magic comment, `frozen_string_literal: true`, that allows strings to be immutable by default. Ruby 3.4 is preparing to make this the default behavior and throws deprecation warnings when mutating strings.

There are many ways to make a mutable string, but I've chosen to use `String.new` because it is the most explicit option and also doesn't require creating multiple string objects

Deprecation warnings are still being thrown by rubyzip. While they have a fix in main, there is no new release and I didn't think it would be appropriate for me to move the dependency to GitHub