### PR TITLE
Add support for rubyzip 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add changelog link to gemspec [605](https://github.com/roo-rb/roo/pull/605)
 - Upgraded rack via usage of rackup
 - Resolve deprecation warnings about uri DEFAULT_PARSER
+- Add support for rubyzip 3.x [629](https://github.com/roo-rb/roo/pull/629)
 
 ### Removed
 - Support for ruby 2.7, 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Removed
 - Support for ruby 2.7, 3.0
+- Support for rubyzip < 3.x
 
 ##  [2.10.1] 2024-01-17
 

--- a/lib/roo/excelx.rb
+++ b/lib/roo/excelx.rb
@@ -333,7 +333,7 @@ module Roo
       wb = entries.find { |e| e.name[/workbook.xml$/] }
       fail ArgumentError 'missing required workbook file' if wb.nil?
 
-      wb.extract(path)
+      wb.extract(File.basename(path), destination_directory: File.dirname(path))
       workbook_doc = Roo::Utils.load_xml(path).remove_namespaces!
       workbook_doc.xpath('//sheet').map { |s| s['id'] }
     end
@@ -357,7 +357,7 @@ module Roo
       wb_rels = entries.find { |e| e.name[/workbook.xml.rels$/] }
       fail ArgumentError 'missing required workbook file' if wb_rels.nil?
 
-      wb_rels.extract(path)
+      wb_rels.extract(File.basename(path), destination_directory: File.dirname(path))
       rels_doc = Roo::Utils.load_xml(path).remove_namespaces!
 
       relationships = rels_doc.xpath('//Relationship').select do |relationship|
@@ -378,7 +378,7 @@ module Roo
         path = "#{tmpdir}/roo_sheet#{i + 1}"
         sheet_files << path
         @sheet_files << path
-        entry.extract(path)
+        entry.extract(File.basename(path), destination_directory: File.dirname(path))
       end
     end
 
@@ -387,7 +387,7 @@ module Roo
       img_entries.each do |entry|
         path = "#{@tmpdir}/roo#{entry.name.gsub(/xl\/|\//, "_")}"
         image_files << path
-        entry.extract(path)
+        entry.extract(File.basename(path), destination_directory: File.dirname(path))
       end
     end
 
@@ -402,7 +402,7 @@ module Roo
         zip_file.read_from_stream zipfilename_or_stream
       end
 
-      process_zipfile_entries zip_file.to_a.sort_by(&:name)
+      process_zipfile_entries zip_file.entries.sort_by(&:name)
     end
 
     def process_zipfile_entries(entries)
@@ -462,7 +462,7 @@ module Roo
           image_rels[nr - 1] = "#{@tmpdir}/roo_image_rels#{nr}"
         end
 
-        entry.extract(path) if path
+        entry.extract(File.basename(path), destination_directory: File.dirname(path)) if path
       end
     end
 

--- a/lib/roo/open_office.rb
+++ b/lib/roo/open_office.rb
@@ -59,7 +59,7 @@ module Roo
         fail ArgumentError, ERROR_MISSING_CONTENT_XML unless content_entry
 
         roo_content_xml_path = ::File.join(@tmpdir, 'roo_content.xml')
-        content_entry.extract(roo_content_xml_path)
+        content_entry.extract('roo_content.xml', destination_directory: @tmpdir)
         decrypt_if_necessary(zip_file, content_entry, roo_content_xml_path, options)
       end
     end
@@ -234,7 +234,7 @@ module Roo
 
       if (manifest_entry = zip_file.glob('META-INF/manifest.xml').first)
         roo_manifest_xml_path = File.join(@tmpdir, 'roo_manifest.xml')
-        manifest_entry.extract(roo_manifest_xml_path)
+        manifest_entry.extract('roo_manifest.xml', destination_directory: @tmpdir)
         manifest        = ::Roo::Utils.load_xml(roo_manifest_xml_path)
 
         # XPath search for manifest:encryption-data only for the content.xml

--- a/roo.gemspec
+++ b/roo.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'nokogiri', '~> 1'
-  spec.add_dependency 'rubyzip', '>= 1.3.0', '< 3.0.0'
+  spec.add_dependency 'rubyzip', '>= 3.0.0', '< 4.0.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'


### PR DESCRIPTION
### Summary

Added support for rubyzip 3.0.0 and made it the minimum required version.

### Other Information

Related issue: https://github.com/roo-rb/roo/issues/621
Rubyzip upgrade instructions: https://github.com/rubyzip/rubyzip/wiki/Updating-to-version-3.x#open