### PR TITLE
chore: Remove RUBY_VERSION condition from gemspec

### DIFF
--- a/roo.gemspec
+++ b/roo.gemspec
@@ -19,12 +19,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version  = ">= 3.1.0"
 
-  if RUBY_VERSION >= '3.4.0'
-    spec.add_dependency 'base64', '~> 0.2'
-    spec.add_dependency 'csv', '~> 3'
-    spec.add_dependency 'logger', '~> 1'
-  end
-
+  spec.add_dependency 'base64', '~> 0.2'
+  spec.add_dependency 'csv', '~> 3'
+  spec.add_dependency 'logger', '~> 1'
   spec.add_dependency 'nokogiri', '~> 1'
   spec.add_dependency 'rubyzip', '>= 3.0.0', '< 4.0.0'
 


### PR DESCRIPTION
The condition depends on the ruby version which is used to build the roo gem and not the ruby version which is used to install the gem.

Luckily the roo-3.0.0 was released with ruby-3.4+, so that these conditional dependencies are registered on rubygems.org. But they also apply when installing on older rubies.

Having a condition on the building ruby version could lead to missing dependencies if roo was built with ruby-3.3. There is no possibility in gemspecs to add dependencies which are dependent on the installing ruby version. So it's best to simply remove the condition.
