### PR TITLE
feat: Support for numbers formatted with "0.00\\ [$EUR]"

### DIFF
--- a/lib/roo/excelx/cell/number.rb
+++ b/lib/roo/excelx/cell/number.rb
@@ -28,14 +28,14 @@ module Roo
           end
         end
 
-        def formatted_value
-          return @cell_value if Excelx::ERROR_VALUES.include?(@cell_value)
+        def formatted_value(format = @format, cell_value = @cell_value)
+          return cell_value if Excelx::ERROR_VALUES.include?(cell_value)
 
-          formatter = generate_formatter(@format)
+          formatter = generate_formatter(format)
           if formatter.is_a? Proc
-            formatter.call(@cell_value)
+            formatter.call(cell_value)
           else
-            Kernel.format(formatter, @cell_value)
+            Kernel.format(formatter, cell_value)
           end
         end
 
@@ -75,6 +75,11 @@ module Roo
             proc do |number|
               formatted_number = generate_formatter($2).call(number)
               "#{$1}#{formatted_number}"
+            end
+          when /^([^\\]+)\\?\s*\[\$([A-Z]+)\]$/ # 0.00\\ [$EUR]
+            proc do |number|
+              formatted_number = formatted_value($1, number)
+              "#{formatted_number} #{$2}"
             end
           else
             raise "Unknown format: #{format.inspect}"

--- a/test/excelx/cell/test_number.rb
+++ b/test/excelx/cell/test_number.rb
@@ -81,7 +81,8 @@ class TestRooExcelxCellNumber < Minitest::Test
       ['#,##0.00;[Red](#,##0.00)', '1,042.00'],
       ['##0.0E+0', '1.0E+03'],
       ["_-* #,##0.00\\ _€_-;\\-* #,##0.00\\ _€_-;_-* \"-\"??\\ _€_-;_-@_-", '1,042.00'],
-      ['@', '1042']
+      ['@', '1042'],
+      ['0.00\\ [$EUR]', '1042.00 EUR']
     ].each do |style_format, result|
       cell = Roo::Excelx::Cell::Number.new '1042', nil, [style_format], nil, nil, nil
       assert_equal result, cell.formatted_value, "Style=#{style_format}"


### PR DESCRIPTION
### Summary

Added support for numbers formatted with "0.00\\ [$EUR]". Tried to make it a bit more general than just this one format string. The "0.00" part can be also some other format, and also the currency code can be any other capital string as well.

Needed to refactor the formatted_value method to take format and number as arguments so that I can call it with the captured format string. 
